### PR TITLE
fix error handling for the case reverted by contract.

### DIFF
--- a/src/ctibroker.py
+++ b/src/ctibroker.py
@@ -16,7 +16,6 @@
 
 import logging
 from contract_visitor import ContractVisitor
-from web3.exceptions import SolidityError
 
 LOGGER = logging.getLogger('common')
 
@@ -50,15 +49,12 @@ class CTIBroker(ContractVisitor):
 
     def buy_token(self, catalog, token, wei, allow_cheaper=False):
         func = self.contract.functions.buyToken(catalog, token, allow_cheaper)
-        try:
-            tx_hash = func.transact({'value': wei})
-            tx_receipt = self.contracts.web3.eth.waitForTransactionReceipt(tx_hash)
-            self.gaslog('buyToken', tx_receipt)
-            if tx_receipt['status'] != 1:
-                LOGGER.error('buyToken: transaction failed')
-                raise Exception('buyToken: transaction failed')
-        except SolidityError as e:
-            LOGGER.error('buyToken: Did you get permission to buy from the private catalog owner?: %s', e)
+        tx_hash = func.transact({'value': wei})
+        tx_receipt = self.contracts.web3.eth.waitForTransactionReceipt(tx_hash)
+        self.gaslog('buyToken', tx_receipt)
+        if tx_receipt['status'] != 1:
+            LOGGER.error('buyToken: transaction failed')
+            raise Exception('buyToken: transaction failed')
 
     def get_amounts(self, catalog, tokens):
         func = self.contract.functions.getAmounts(catalog, tokens)

--- a/src/inventory.py
+++ b/src/inventory.py
@@ -176,8 +176,7 @@ class Inventory:
         self.catalog.update_balanceof_myself(token_address)
 
     def is_catalog_private(self):
-        assert self.catalog
-        return self.catalog.is_private
+        return self.catalog.is_private if self.catalog else False
 
     def set_private(self):
         assert self.catalog


### PR DESCRIPTION
エラー要因は不許可・Ether不足・その他と色々考えられますが、例外から判別することは困難と思われるため、HTTPError(Bad Request) あるいは ValueError を受けた場合は共通メッセージを出力するように改修しました。プライベートカタログで購入処理を行った場合に限り、追加でプライベートカタログ向けの補足メッセージを出力しています。