### PR TITLE
add menu 24: modify tokeninfo

### DIFF
--- a/src/client.py
+++ b/src/client.py
@@ -417,6 +417,18 @@ class Controller():
             return
         deal_func(token_address, amount)
 
+    def modify_asset(self):
+        hook = lambda: self.view.vio.pager_print(
+            'パラメータ変更するトークンを選択してください')
+        token_address, asset = self.view.token_selector(
+            mode='token_publisher', hook=hook)
+        if not token_address:
+            return
+        new_asset = self.view.modify_asset_screen(token_address, asset)
+        if new_asset is None:
+            return
+        self.model.update_catalog(token_address, new_asset)
+
     def cancel_task(self):
         if not self.model.operator_address:
             self.view.missing_screen('オペレータ')

--- a/src/client_model.py
+++ b/src/client_model.py
@@ -463,6 +463,9 @@ class Player():
     def unregister_catalog(self, token_address):
         self.inventory.unregister_token(token_address)
 
+    def update_catalog(self, token_address, cti_metadata):
+        self.inventory.modify_token(token_address, cti_metadata)
+
     @staticmethod
     def save_registered_token(cti_metadata):
         # cticatalog コントラクトに登録したtokenのmetadataを保存する

--- a/src/client_ui.py
+++ b/src/client_ui.py
@@ -170,6 +170,7 @@ class SimpleCUI():
             (21, 'challenge_acception', 'チャレンジの受付開始・解除'),
             (22, 'dealing', '発行トークンの追加委託・引取・登録取消'),
             (23, 'publish_misp', 'ローカルMISPデータからのCTIトークン自動配布'),
+            (24, 'modify_asset', 'CTIトークンのパラメータ変更'),
             ]
         if self.model.dev:
             menu.extend([
@@ -551,6 +552,53 @@ class SimpleCUI():
         asset['quantity'] = asset_quantity
         asset['operator'] = operator_id
         return asset, num_consign
+
+    def modify_asset_screen(self, token_address, current):
+        self.vio.print('----CTIトークンパラメータを変更します----')
+        self.vio.print('(UUIDは変更できません)')
+
+        if self.select_yes_no_screen(hint='タイトルを変更しますか？'):
+            self.vio.print('タイトルを入力してください')
+            asset_title = self.vio.input().strip()
+        else:
+            asset_title = current['title']
+
+        if self.select_yes_no_screen(hint='価格を変更しますか？'):
+            asset_price = self.input_int_screen(name='価格', minimum=0)
+            if asset_price is None:
+                return None
+        else:
+            asset_price = current['price']
+
+        if self.select_yes_no_screen(hint='オペレータを変更しますか？'):
+            self.vio.print('オペレータを入力してください')
+            operator_id = self.vio.input().strip()
+        else:
+            operator_id = current['operator']
+
+        if current['title'] == asset_title and \
+                current['price'] == asset_price and \
+                current['operator'] == operator_id:
+            self.vio.print('変更点がありません')
+            return None
+
+        self.vio.print('--[確認]--')
+        self.vio.print('  アドレス: {}'.format(token_address))
+        self.vio.print('      UUID: {}'.format(current['uuid']))
+        self.vio.print('  タイトル: "{}"'.format(asset_title))
+        self.vio.print('      価格: {}'.format(asset_price))
+        self.vio.print('オペレータ: {}'.format(operator_id))
+        self.vio.print('----')
+        if not self.select_yes_no_screen(
+                hint='この内容でCTIトークンパラメータを更新しますか？'):
+            return None
+
+        asset = dict()
+        asset['uuid'] = current['uuid']
+        asset['title'] = asset_title
+        asset['price'] = asset_price
+        asset['operator'] = operator_id
+        return asset
 
     def start_challenge(self, task_id):
         self.vio.print('--------------------')

--- a/src/inventory.py
+++ b/src/inventory.py
@@ -151,6 +151,10 @@ class Inventory:
             # すぐに catalog_token から抹消されるので amount 更新は割愛
         self.catalog.unregister_token(token_address)
 
+    def modify_token(self, token_address, metadata):
+        assert self.catalog
+        self.catalog.modify_token(token_address, metadata)
+
     def like_cti(self, token_address):
         assert self.catalog
         self.catalog.like_cti(token_address)
@@ -361,6 +365,14 @@ class Catalog:
 
     def unregister_token(self, token_address):
         self.cticatalog.unregister_cti(token_address)
+
+    def modify_token(self, token_address, metadata):
+        self.cticatalog.modify_cti(
+            token_address,
+            metadata['uuid'],
+            metadata['title'],
+            metadata['price'],
+            metadata['operator'])
 
     def list_token_uris(self):
         return self.cticatalog.list_token_uris()


### PR DESCRIPTION
カタログのトークン情報（タイトル・価格・オペレータ）を変更するメニュー「24: CTIトークンのパラメータ変更」を追加しました。

- UUID は、別途相談させていただいたとおり、変更不可としています。
- スマートコントラクトCTICatalog には該当する関数 modifyCti() が（UUID変更不可な実装で）既に存在します。
- スマートコントラクトCTIBroker でのトークン購入処理は、購入トランザクション時点でのカタログから価格を参照する実装になっています。
以上の状況により、既にデプロイされているカタログ・ブローカーにおいても、追加した変更メニューが使用できます。 