### PR TITLE
refine around transaction failure

### DIFF
--- a/src/contract_visitor.py
+++ b/src/contract_visitor.py
@@ -209,8 +209,7 @@ class ContractVisitor(Visitor):
         tx_receipt = self.contracts.web3.eth.waitForTransactionReceipt(tx_hash)
         self.gaslog('deploy', tx_receipt)
         if tx_receipt['status'] != 1:
-            LOGGER.error('deploy: transaction failed')
-            raise Exception('Contract deploy failed: {}'.format(
+            raise ValueError('Contract deploy failed: {}'.format(
                 self.contract_src))
 
         return tx_receipt['contractAddress']

--- a/src/ctibroker.py
+++ b/src/ctibroker.py
@@ -35,8 +35,7 @@ class CTIBroker(ContractVisitor):
         tx_receipt = self.contracts.web3.eth.waitForTransactionReceipt(tx_hash)
         self.gaslog('consignToken', tx_receipt)
         if tx_receipt['status'] != 1:
-            LOGGER.error('consignToken: transaction failed')
-            raise Exception('consignToken: transaction failed')
+            raise ValueError('consignToken: transaction failed')
 
     def takeback_token(self, catalog, token, amount):
         func = self.contract.functions.takebackToken(catalog, token, amount)
@@ -44,8 +43,7 @@ class CTIBroker(ContractVisitor):
         tx_receipt = self.contracts.web3.eth.waitForTransactionReceipt(tx_hash)
         self.gaslog('takebackToken', tx_receipt)
         if tx_receipt['status'] != 1:
-            LOGGER.error('takebackToken: transaction failed')
-            raise Exception('takebackToken: transaction failed')
+            raise ValueError('takebackToken: transaction failed')
 
     def buy_token(self, catalog, token, wei, allow_cheaper=False):
         func = self.contract.functions.buyToken(catalog, token, allow_cheaper)
@@ -53,8 +51,7 @@ class CTIBroker(ContractVisitor):
         tx_receipt = self.contracts.web3.eth.waitForTransactionReceipt(tx_hash)
         self.gaslog('buyToken', tx_receipt)
         if tx_receipt['status'] != 1:
-            LOGGER.error('buyToken: transaction failed')
-            raise Exception('buyToken: transaction failed')
+            raise ValueError('buyToken: transaction failed')
 
     def get_amounts(self, catalog, tokens):
         func = self.contract.functions.getAmounts(catalog, tokens)

--- a/src/cticatalog.py
+++ b/src/cticatalog.py
@@ -40,8 +40,7 @@ class CTICatalog(ContractVisitor):
         tx_receipt = self.contracts.web3.eth.waitForTransactionReceipt(tx_hash)
         self.gaslog('publishCti', tx_receipt)
         if tx_receipt['status'] != 1:
-            LOGGER.error('publishCti: transaction failed')
-            raise Exception('Transaction failed: publishCti')
+            raise ValueError('Transaction failed: publishCti')
 
     def register_cti(self, token_address, uuid, title, price, operator):
         func = self.contract.functions.registerCti(
@@ -50,8 +49,7 @@ class CTICatalog(ContractVisitor):
         tx_receipt = self.contracts.web3.eth.waitForTransactionReceipt(tx_hash)
         self.gaslog('registerCti', tx_receipt)
         if tx_receipt['status'] != 1:
-            LOGGER.error('registerCti: transaction failed')
-            raise Exception('Transaction failed: registerCti')
+            raise ValueError('Transaction failed: registerCti')
 
     def modify_cti(self, token_address, uuid, title, price, operator):
         func = self.contract.functions.modifyCti(
@@ -60,8 +58,7 @@ class CTICatalog(ContractVisitor):
         tx_receipt = self.contracts.web3.eth.waitForTransactionReceipt(tx_hash)
         self.gaslog('modifyCti', tx_receipt)
         if tx_receipt['status'] != 1:
-            LOGGER.error('modifyCti: transaction failed')
-            raise Exception('Transaction failed: modifyCti')
+            raise ValueError('Transaction failed: modifyCti')
 
     def unregister_cti(self, token_address):
         func = self.contract.functions.unregisterCti(token_address)
@@ -69,8 +66,7 @@ class CTICatalog(ContractVisitor):
         tx_receipt = self.contracts.web3.eth.waitForTransactionReceipt(tx_hash)
         self.gaslog('unregisterCti', tx_receipt)
         if tx_receipt['status'] != 1:
-            LOGGER.error('unregisterCti: transaction failed')
-            raise Exception('Transaction failed: unregisterCti')
+            raise ValueError('Transaction failed: unregisterCti')
 
     def list_token_uris(self):
         func = self.contract.functions.listTokenURIs()
@@ -88,8 +84,7 @@ class CTICatalog(ContractVisitor):
         tx_receipt = self.contracts.web3.eth.waitForTransactionReceipt(tx_hash)
         self.gaslog('likeCti', tx_receipt)
         if tx_receipt['status'] != 1:
-            LOGGER.error('likeCti: transaction failed')
-            raise Exception('Transaction failed: likeCti')
+            raise ValueError('Transaction failed: likeCti')
 
     def get_like_event(self, search_blocks=1000):
         # 最大search_blocks数だけ、CtiLiked eventを取得して返す
@@ -111,8 +106,7 @@ class CTICatalog(ContractVisitor):
         tx_receipt = self.contracts.web3.eth.waitForTransactionReceipt(tx_hash)
         self.gaslog('setPrivate', tx_receipt)
         if tx_receipt['status'] != 1:
-            LOGGER.error('setPrivate: transaction failed')
-            raise Exception('Transaction failed: setPrivate')
+            raise ValueError('Transaction failed: setPrivate')
 
     def set_public(self):
         func = self.contract.functions.setPublic()
@@ -120,8 +114,7 @@ class CTICatalog(ContractVisitor):
         tx_receipt = self.contracts.web3.eth.waitForTransactionReceipt(tx_hash)
         self.gaslog('setPublic', tx_receipt)
         if tx_receipt['status'] != 1:
-            LOGGER.error('setPublic: transaction failed')
-            raise Exception('Transaction failed: setPublic')
+            raise ValueError('Transaction failed: setPublic')
 
     def authorize_user(self, eoa_address):
         func = self.contract.functions.authorizeUser(eoa_address)
@@ -129,8 +122,7 @@ class CTICatalog(ContractVisitor):
         tx_receipt = self.contracts.web3.eth.waitForTransactionReceipt(tx_hash)
         self.gaslog('authorizeUser', tx_receipt)
         if tx_receipt['status'] != 1:
-            LOGGER.error('authorizeUser: transaction failed')
-            raise Exception('Transaction failed: authorizeUser')
+            raise ValueError('Transaction failed: authorizeUser')
 
     def revoke_user(self, eoa_address):
         func = self.contract.functions.revokeUser(eoa_address)
@@ -138,8 +130,7 @@ class CTICatalog(ContractVisitor):
         tx_receipt = self.contracts.web3.eth.waitForTransactionReceipt(tx_hash)
         self.gaslog('revokeUser', tx_receipt)
         if tx_receipt['status'] != 1:
-            LOGGER.error('revokeUser: transaction failed')
-            raise Exception('Transaction failed: revokeUser')
+            raise ValueError('Transaction failed: revokeUser')
 
     def show_authorized_users(self):
         func = self.contract.functions.showAuthorizedUsers()

--- a/src/ctioperator.py
+++ b/src/ctioperator.py
@@ -34,90 +34,55 @@ class CTIOperator(ContractVisitor):
 
     def set_recipient(self):
         func = self.contract.functions.recipientFor(self.contract_address)
-        LOGGER.info('call recipientFor(%s)', self.contract_address)
         tx_hash = func.transact()
         tx_receipt = self.contracts.web3.eth.waitForTransactionReceipt(tx_hash)
         self.gaslog('recipientFor', tx_receipt)
         if tx_receipt['status'] != 1:
-            LOGGER.error('recipientFor: transaction failed')
-            return False
-        LOGGER.debug(tx_receipt)
-        return True
+            raise ValueError('Transaction failed: recipientFor')
 
     def register_recipient(self):
         func = self.contract.functions.registerRecipient(self.contract_address)
-        LOGGER.info('call recipientFor(%s)', self.contract_address)
         tx_hash = func.transact()
         tx_receipt = self.contracts.web3.eth.waitForTransactionReceipt(tx_hash)
         self.gaslog('registerRecipient', tx_receipt)
         if tx_receipt['status'] != 1:
-            LOGGER.error('registerRecipient: transaction failed')
-            return False
-        LOGGER.debug(tx_receipt)
-        return True
+            raise ValueError('Transaction failed: registerRecipient')
 
     def register_tokens(self, token_addresses):
-        try:
-            func = self.contract.functions.register(token_addresses)
-            tx_hash = func.transact()
-            tx_receipt = \
-                self.contracts.web3.eth.waitForTransactionReceipt(tx_hash)
-            self.gaslog('register', tx_receipt)
-            if tx_receipt['status'] == 1:
-                LOGGER.info('register succeeded: %s', token_addresses)
-            else:
-                raise Exception("transaction failed")
-        except Exception as err:
-            LOGGER.error(err)
-            LOGGER.error('register failed')
+        func = self.contract.functions.register(token_addresses)
+        tx_hash = func.transact()
+        tx_receipt = self.contracts.web3.eth.waitForTransactionReceipt(tx_hash)
+        self.gaslog('register', tx_receipt)
+        if tx_receipt['status'] != 1:
+            raise ValueError('Transaction failed: register')
+        LOGGER.info('register succeeded: %s', token_addresses)
 
     def unregister_tokens(self, token_addresses):
-        try:
-            func = self.contract.functions.unregister(token_addresses)
-            tx_hash = func.transact()
-            tx_receipt = \
-                self.contracts.web3.eth.waitForTransactionReceipt(tx_hash)
-            self.gaslog('unregister', tx_receipt)
-            if tx_receipt['status'] == 1:
-                LOGGER.info('unregister succeeded: %s', token_addresses)
-            else:
-                raise Exception("transaction failed")
-        except Exception as err:
-            LOGGER.error(err)
-            LOGGER.error('unregister failed')
+        func = self.contract.functions.unregister(token_addresses)
+        tx_hash = func.transact()
+        tx_receipt = self.contracts.web3.eth.waitForTransactionReceipt(tx_hash)
+        self.gaslog('unregister', tx_receipt)
+        if tx_receipt['status'] != 1:
+            raise ValueError('Transaction failed: unregister')
+        LOGGER.info('unregister succeeded: %s', token_addresses)
 
     def accept_task(self, task_id):
-        try:
-            func = self.contract.functions.accepted(task_id)
-            tx_hash = func.transact()
-            tx_receipt = \
-                self.contracts.web3.eth.waitForTransactionReceipt(tx_hash)
-            self.gaslog('accepted', tx_receipt)
-            if tx_receipt['status'] == 1:
-                LOGGER.info('accept_task succeeded')
-            else:
-                raise Exception("transaction failed")
-            return True
-        except Exception as err:
-            LOGGER.error(err)
-            LOGGER.error('accept_task failed')
-            return False
+        func = self.contract.functions.accepted(task_id)
+        tx_hash = func.transact()
+        tx_receipt = self.contracts.web3.eth.waitForTransactionReceipt(tx_hash)
+        self.gaslog('accepted', tx_receipt)
+        if tx_receipt['status'] != 1:
+            raise ValueError('Transaction failed: accepted')
+        LOGGER.info('accept_task succeeded: %s', task_id)
 
     def finish_task(self, task_id, data=''):
-        try:
-            func = self.contract.functions.finish(task_id, data)
-            tx_hash = func.transact()
-            tx_receipt = \
-                self.contracts.web3.eth.waitForTransactionReceipt(tx_hash)
-            self.gaslog('finish', tx_receipt)
-            if tx_receipt['status'] == 1:
-                LOGGER.info('finish_task succeeded')
-            else:
-                raise Exception("transaction failed")
-            LOGGER.debug('finish() transaction: %s', tx_receipt)
-        except Exception as err:
-            LOGGER.error(err)
-            LOGGER.error('finish_task failed')
+        func = self.contract.functions.finish(task_id, data)
+        tx_hash = func.transact()
+        tx_receipt = self.contracts.web3.eth.waitForTransactionReceipt(tx_hash)
+        self.gaslog('finish', tx_receipt)
+        if tx_receipt['status'] != 1:
+            raise ValueError('Transaction failed: finish')
+        LOGGER.info('finish_task succeeded: %s', task_id)
 
     def cancel_challenge(self, task_id):
         func = self.contract.functions.cancelTask(task_id)
@@ -125,8 +90,7 @@ class CTIOperator(ContractVisitor):
         tx_receipt = self.contracts.web3.eth.waitForTransactionReceipt(tx_hash)
         self.gaslog('cancelTask', tx_receipt)
         if tx_receipt['status'] != 1:
-            LOGGER.error('cancelTask: transaction failed')
-            raise Exception("cancelTask: transaction failed")
+            raise ValueError('Transaction failed: cancelTask')
 
     def reemit_pending_tasks(self):
         func = self.contract.functions.reemitPendingTasks()
@@ -134,5 +98,4 @@ class CTIOperator(ContractVisitor):
         tx_receipt = self.contracts.web3.eth.waitForTransactionReceipt(tx_hash)
         self.gaslog('reemitPendingTasks', tx_receipt)
         if tx_receipt['status'] != 1:
-            LOGGER.error('reemitPendingTasks: transaction failed')
-            raise Exception("reemitPendingTasks: transaction failed")
+            raise ValueError('Transaction failed: reemitPendingTasks')

--- a/src/ctitoken.py
+++ b/src/ctitoken.py
@@ -41,9 +41,7 @@ class CTIToken(ContractVisitor):
         tx_receipt = self.contracts.web3.eth.waitForTransactionReceipt(tx_hash)
         self.gaslog('send', tx_receipt)
         if tx_receipt['status'] != 1:
-            LOGGER.error('send_token: transaction failed')
-            return None
-        return tx_receipt
+            raise ValueError('Transaction failed: send')
 
     def burn_token(self, amount, data=''):
         func = self.contract.functions.burn(amount, data)
@@ -51,8 +49,7 @@ class CTIToken(ContractVisitor):
         tx_receipt = self.contracts.web3.eth.waitForTransactionReceipt(tx_hash)
         self.gaslog('burn', tx_receipt)
         if tx_receipt['status'] != 1:
-            LOGGER.error('burn_token: transaction failed')
-            raise Exception('burn_token: transaction failed')
+            raise ValueError('Transaction failed: burn')
 
     def authorize_operator(self, operator):
         func = self.contract.functions.authorizeOperator(operator)
@@ -60,8 +57,7 @@ class CTIToken(ContractVisitor):
         tx_receipt = self.contracts.web3.eth.waitForTransactionReceipt(tx_hash)
         self.gaslog('authorizeOperator', tx_receipt)
         if tx_receipt['status'] != 1:
-            LOGGER.error('authoerizeOperator: transaction failed')
-            raise Exception('authoerizeOperator: transaction failed')
+            raise ValueError('Transaction failed: authorizeOperator')
 
     def revoke_operator(self, operator):
         func = self.contract.functions.revokeOperator(operator)
@@ -69,5 +65,4 @@ class CTIToken(ContractVisitor):
         tx_receipt = self.contracts.web3.eth.waitForTransactionReceipt(tx_hash)
         self.gaslog('revokeOperator', tx_receipt)
         if tx_receipt['status'] != 1:
-            LOGGER.error('revokeOperator: transaction failed')
-            raise Exception('revokeOperator: transaction failed')
+            raise ValueError('Transaction failed: revokeOperator')

--- a/src/plugins/gcs_solver.py
+++ b/src/plugins/gcs_solver.py
@@ -44,21 +44,18 @@ class Solver(BaseSolver):
             view.vio.print('Solver用のURLが設定されていません。')
 
     def process_challenge(self, token_address, event):
-        LOGGER.info('Solver: callback: %s', token_address)
+        LOGGER.info('GCSSolver: callback: %s', token_address)
         LOGGER.debug(event)
-        try:
-            task_id = event['args']['taskId']
-            challenge_seeker = event['args']['from']
-            LOGGER.info(
-                'accepting task %s from seeker %s', task_id, challenge_seeker)
-            if not self.accept_task(task_id):
-                LOGGER.info('could not accept task %s', task_id)
-                return
-            LOGGER.info('accepted task %s', task_id)
-        except Exception as err:
-            LOGGER.exception(err)
+
+        task_id = event['args']['taskId']
+        challenge_seeker = event['args']['from']
+        LOGGER.info(
+            'accepting task %s from seeker %s', task_id, challenge_seeker)
+        if not self.accept_task(task_id):
+            LOGGER.warning('could not accept task %s', task_id)
             return
 
+        LOGGER.info('accepted task %s', task_id)
         data = ''
         try:
             try:

--- a/src/plugins/standalone_solver.py
+++ b/src/plugins/standalone_solver.py
@@ -97,21 +97,18 @@ class Solver(BaseSolver):
         super().destroy()
 
     def process_challenge(self, token_address, event):
-        LOGGER.info('Solver: callback: %s', token_address)
+        LOGGER.info('StandaloneSolver: callback: %s', token_address)
         LOGGER.debug(event)
-        try:
-            task_id = event['args']['taskId']
-            challenge_seeker = event['args']['from']
-            LOGGER.info(
-                'accepting task %s from seeker %s', task_id, challenge_seeker)
-            if not self.accept_task(task_id):
-                LOGGER.info('could not accept task %s', task_id)
-                return
-            LOGGER.info('accepted task %s', task_id)
-        except Exception as err:
-            LOGGER.exception(err)
+
+        task_id = event['args']['taskId']
+        challenge_seeker = event['args']['from']
+        LOGGER.info(
+            'accepting task %s from seeker %s', task_id, challenge_seeker)
+        if not self.accept_task(task_id):
+            LOGGER.warning('could not accept task %s', task_id)
             return
 
+        LOGGER.info('accepted task %s', task_id)
         data = ''
         try:
             # process for Demo

--- a/src/seeker.py
+++ b/src/seeker.py
@@ -27,11 +27,8 @@ class Seeker():
     def challenge(self, operator_address, token_address, data=''):
         # tokenをoperatorに送信
         # operatorデプロイ時にrecipientFor実行し、token受領時の動作設定済
-        tx_receipt = self.contracts.accept(CTIToken()).get(token_address).\
-            send_token(operator_address, data=data)
-        if tx_receipt['status'] != 1:
-            return False
-        return True
+        self.contracts.accept(CTIToken()).get(token_address).\
+            send_token(operator_address, amount=1, data=data)
 
     def cancel_challenge(self, operator_address, task_id):
         operator = self.contracts.accept(CTIOperator()).get(operator_address)


### PR DESCRIPTION
#16 の改修に合わせ、トランザクションエラー周りを整理しました。
- receipt が返され、かつ status が 1 でないケースで発していた Exception を ValueError に変更しました。この変更により、件の generic なトランザクションエラーとして扱われます。ただ、当該処理は EthereumTesterProvider をメインに開発していた頃の名残で、少なくとも pricom では発生しない（HTTPError になる）模様です。
- 上記の改修時に気付いた、冗長なエラーメッセージや不要な返り値も合わせて整理しました。
- EthereumTesterProvider では Ether 不足時に ValidationError が発せられるので対応しました。
- 初期化処理（主に erc1820 + ライブラリ）でのエラーメッセージを調整しました。
- 別スレッドで駆動される eventlistener が起点の処理については整理が中途半端です。solver 周りを見直すことになると思うので、その際に再整理します。