### PR TITLE
Topic/tiny updates

### DIFF
--- a/KnownErrors.md
+++ b/KnownErrors.md
@@ -1,0 +1,113 @@
+# 既知のエラーと対処方法
+
+
+
+### クライアントを起動できない
+
+```
+$ ./metemcyber_ctl.sh pricom client -f ~/.ethereum/keystore/UTC--my-keyfile
+initializing ./workspace/docker.env.
+docker: Error response from daemon: network metemcyber-pricom not found.
+```
+
+初期構築が未実施です。`metemcyber_ctl.sh pricom init` を実行してください。
+
+---
+
+```
+$ ./metemcyber_ctl.sh pricom client alice
+not yet initialized
+```
+
+alice, bob, carol のアカウントはテストプロバイダ環境（ganache や besu）でのみ使用可能です。pricom では使用できません。
+
+---
+
+```
+$ ./metemcyber_ctl.sh pricom client -f ~/.ethereum/keystore/UTC--my-keyfile
+Enter password for keyfile:
+ERROR: MAC mismatch
+cannot decode keyfile: UTC--my-keyfile
+```
+
+キーファイルに対するパスワード違いで発生します。
+正しいパスワードを入力してください。
+
+---
+
+### クライアント操作でエラーが発生する
+
+```
+requests.exceptions.HTTPError: 400 Client Error: Bad Request for url: https://rpc.metemcyber.ntt.com/
+```
+
+Ether を消費する操作を行った場合であれば、保有 Ether が不足している可能性があります。保有 Ether 量を確認し、必要であれば補充してください。誤ったアカウントでログインしている可能性も考えられます。
+
+クライアントプログラム起動直後に発生する場合、workspace.pricom/config.ini が破損している可能性があります。最新の config.ini を取得・配置してください。
+
+### チャレンジに失敗する
+
+```
+チャレンジトークンが返還されました: 0x2188775902595a880c4C2FC682602D1f71c18209
+メッセージが添付されています: cannot sendback result via webhook: <urlopen error [Errno -2] Name or service not known>
+（あるいは）
+メッセージが添付されています: cannot sendback result via webhook: <urlopen error [Errno 99] Cannot assign requested address>
+（など）
+```
+
+あなたが実行しているクライアントプログラムに対する、トークン提供者の solver プログラムからの webhook 接続が失敗しています。前者（Name or service not known）は URL の名前解決に失敗した場合、後者（Cannot assign requested address）は名前解決できたが接続拒否された場合に発生します。timeout など、他のエラーメッセージの場合もあります。
+
+metemcyber のマニュアルをご参照のうえ、必要であれば ngrok のセットアップなどを実施してください。また、クライアントプログラム実行時のオプション指定間違いなどにご注意ください。
+
+なお、ネットワーク接続障害は metemcyber とは無関係に発生している可能性も考えられます。metemcyber とは別のプログラム（例えばWebブラウザ）などで接続性を確認し、問題がある場合は当該ネットワークの管理者にご確認ください。
+
+* 補足
+
+  名前解決の失敗は、クライアントプログラム実行時の -w オプションの付け忘れで発生しやすいです。その他のエラーは firewall によるアクセス制限などが考えられます。dockerの問題（コンテナ-ホスト間通信）に起因するケースもあるようです。
+
+---
+
+```
+チャレンジトークンが返還されました: 0x2188775902595a880c4C2FC682602D1f71c18209
+メッセージが添付されています: Challenge failed by solver side error
+```
+
+トークン出品者の solver プログラムで生じた不具合により、チャレンジが失敗しています。（現在の実装仕様では、購入者側ではチャレンジを再実行する以外に行えることはありません）
+
+* トークン出品者（solver プログラム稼働者）側へのヒント
+
+  ストレージサービスへのアップロードに失敗している可能性が考えられます。API キーが正しく、また失効していないことを確認してください。
+
+---
+
+```
+-------------------- 
+チャレンジの処理を開始しました
+-------------------- 
+と表示された後、いつまで経っても完了しない（成否が表示されない）
+```
+
+まず、メニューの「[12]タスク（チャレンジ）のキャンセル」を実行してください。ここで「選択できるアイテムがありません」と表示される場合、既にタスクは受理されており処理中です。そのままお待ちください。
+
+実行したタスクがリストに表示される場合、当該タスクは未受理状態です。当該トークンの出品者が solver プログラムを稼働させていないか、不具合が生じている可能性があります。seeker プログラム（クライアントプログラム）を停止したいような場合、タスクをキャンセルして後に再実行することもできます。キャンセルするとチャレンジトークンは返還されます。
+
+---
+```
+--------------------
+チャレンジに成功しました！！！
+--------------------
+受信 URL: https://storage.googleapis.com/metemcyber-storage-1/81f608afa......
+トークン: 0x8b295504c23E9Aa5f7dA30d574B4a9e2CA06cA61
+チャレンジ結果を受信しましたが、受信URLからのダウンロードに失敗しました: <urlopen error [Errno -2] Name or service not known>
+手動でダウンロードしてください
+```
+
+何らかの理由により、クライアントプログラムから指定URLへのアクセスに失敗しています。プロキシサーバが介在するようなネットワーク環境で発生しがちです。
+表示されているURLから、Webブラウザなどを使用して手動でダウンロードしてください。
+なお、提示されているダウンロードURLは一定時間で失効する場合がありますので、ご留意ください。
+
+* 補足
+
+  metemcyber.settings に `HTTP_PROXY`, `HTTPS_PROXY` の環境変数を設定することで解決する可能性があります。
+
+

--- a/setup_demo_catalog.in
+++ b/setup_demo_catalog.in
@@ -1,8 +1,8 @@
 1
 901
 
-
 n
+
 902
 @standalone_solver.py
 20

--- a/src/client.py
+++ b/src/client.py
@@ -247,12 +247,15 @@ class Controller():
             'カタログコントラクトアドレス', hint='新規作成')
         if catalog_address is None:
             return
+        if catalog_address == '':
+            is_private = self.view.select_yes_no_screen(
+                hint='プライベートカタログとして作成しますか？')
+        else:
+            is_private = False
         broker_address = self.view.input_address_screen(
             'ブローカーコントラクトアドレス', hint='新規作成')
         if broker_address is None:
             return
-        is_private = self.view.select_yes_no_screen(
-            hint='プライベートカタログとして作成しますか？')
         self.model.setup_inventory(catalog_address, broker_address, is_private)
         self.view.setup_broker_done(
             self.model.inventory.catalog_address,

--- a/src/client.py
+++ b/src/client.py
@@ -120,7 +120,7 @@ class Controller():
             '\n'
             'connecting to Ethereum Blockchain...\n'
             'Endpoint: ' + str(provider) + '\n'
-            'EoA address: ' + account_id)
+            'EOA address: ' + account_id)
 
         try:
             self.model = Player(

--- a/src/client_model.py
+++ b/src/client_model.py
@@ -212,10 +212,16 @@ class Player():
             self.save_config()
 
     def _fix_config_address(self, target):
+        if target is None or target.strip() == '':
+            return None
         if self.web3.isChecksumAddress(target):
             return target
+
         if self.web3.isAddress(target):
-            return self.web3.toChecksumAddress(target)
+            LOGGER.error('not a mixed-case checksum address: %s', target)
+        else:
+            LOGGER.error('not a valid address: %s', target)
+        LOGGER.warning('ignored above config param')
         return None
 
     def load_config(self):

--- a/src/client_model.py
+++ b/src/client_model.py
@@ -550,8 +550,7 @@ class Player():
             # トークン送付したので情報更新する
             self.inventory.update_balanceof_myself(token_address)
 
-    @staticmethod
-    def receive_challenge_answer(data):
+    def receive_challenge_answer(self, data):
         try:
             # data is generated at Solver.webhook().
             download_url = data['download_url']
@@ -576,6 +575,8 @@ class Player():
                 'チャレンジ結果を受信しましたが、受信URLからの' + \
                 'ダウンロードに失敗しました: ' + str(err) + '\n'
             msg += '手動でダウンロードしてください\n'
+            msg += '\n'
+            msg += self._save_download_url(token_address, download_url)
             return True, msg
 
         try:
@@ -583,7 +584,7 @@ class Player():
             title = jdata['Event']['info']
         except:
             title = '（解析できませんでした）'
-        msg += '取得データタイトル: ' + title
+        msg += '取得データタイトル: ' + title + '\n'
 
         try:
             if not os.path.isdir(DOWNLOADED_CTI_PATH):
@@ -591,11 +592,27 @@ class Player():
             filepath = '{}/{}.json'.format(DOWNLOADED_CTI_PATH, token_address)
             with open(filepath, 'wb') as fout:
                 fout.write(rdata)
-            msg += '\n取得データを保存しました: ' + filepath
+            msg += '取得データを保存しました: ' + filepath + '\n'
         except Exception as err:
-            msg += '\n取得データの保存に失敗しました: ' + str(err)
-            msg += '\n手動で再取得してください'
+            msg += '取得データの保存に失敗しました: ' + str(err) + '\n'
+            msg += '手動で再取得してください\n'
+            msg += '\n'
+            msg += self._save_download_url(token_address, download_url)
         return True, msg
+
+    @staticmethod
+    def _save_download_url(token_address, download_url):
+        try:
+            if not os.path.isdir(DOWNLOADED_CTI_PATH):
+                os.makedirs(DOWNLOADED_CTI_PATH)
+            filepath = '{}/{}.url'.format(
+                DOWNLOADED_CTI_PATH, token_address)
+            with open(filepath, 'w') as fout:
+                fout.write(download_url)
+            msg = 'ダウンロードURLを保存しました: ' + filepath + '\n'
+        except Exception as err:
+            msg = 'ダウンロードURLの保存に失敗しました: ' + str(err) + '\n'
+        return msg
 
     def cancel_challenge(self, task_id):
         assert self.operator_address

--- a/src/client_ui.py
+++ b/src/client_ui.py
@@ -746,8 +746,12 @@ class SimpleCUI():
                     return default + ext_str
                 return '' + ext_str
 
-            if not self.model.web3.isAddress(target.lower()):
+            if not self.model.web3.isChecksumAddress(target):
                 self.vio.print('正しいアドレスではありません')
+                if self.model.web3.isAddress(target):
+                    self.vio.print(
+                        'EIP55準拠(mixed-case checksum address)の'
+                        '形式で入力してください')
                 continue
             return self.model.web3.toChecksumAddress(target) + ext_str
 

--- a/src/client_ui.py
+++ b/src/client_ui.py
@@ -230,7 +230,7 @@ class SimpleCUI():
         pout('--------------------')
         pout('アカウント情報')
         pout('■ サマリー')
-        pout(' - EoAアドレス: {}'.format(self.model.account_id))
+        pout(' - EOAアドレス: {}'.format(self.model.account_id))
         pout(' - 所持ETH: {} Wei'.format(eth))
         pout('■ コントラクト')
         pout(' - カタログアドレス: {}'.format(catalog_address))


### PR DESCRIPTION
- 既知のエラーと対処方法について、KnownErrors.md にまとめました。
- config.ini およびアドレス入力画面で入力されたアドレスに対し、EIP55(mixed-case checksum address)で検証するように改修しました。
- チャレンジで受け取ったURLからダウンロードに失敗した、あるいはデータ保存に失敗した際に、ダウンロードURLをファイルに保存するように改修しました。
- カタログのプライベート属性の選択を、カタログ切替時には行わないように改修しました。
- EoA と表記していた箇所を EOA に修正しました。

これまでは入力アドレスを EIP55 準拠となるよう自動変換しており、入力ミスを回避するという目的に逆行していましたので、改修しました。
自身の EOA アドレスは依然として自動変換していますが、これは geth の生成するアドレスが EIP55 準拠でないためです。プライベートキーと組み合わせるので入力ミスがあっても問題にはならないと考えています。