### PR TITLE
Topic/#43 add misp feed

### DIFF
--- a/feed_downloaded_events.sh
+++ b/feed_downloaded_events.sh
@@ -1,0 +1,23 @@
+#! /bin/bash
+
+# Directory to store downloaded MISP event files.
+# should be same with DOWNLOADED_CTI_PATH in src/client_model.py.
+DOWNLOAD_DIR=./download
+
+# Directory to store feed file for MISP.
+MISP_FEEDDIR=./misp_feed
+
+# PORT number which accepts http access for MISP feed
+PORT=8080
+
+workdir=`cd \`dirname $0\` && pwd`
+
+[ ! -f "${workdir}/venv/bin/activate" ] \
+    && echo "python-venv is not ready." \
+    && exit 255
+
+args="-i '${DOWNLOAD_DIR}' -o '${MISP_FEEDDIR}' -s -p ${PORT}"
+source venv/bin/activate || exit 255
+cmd="python3 src/generate_feed.py ${args}"
+echo >&2 $cmd
+eval $cmd

--- a/src/generate_feed.py
+++ b/src/generate_feed.py
@@ -1,0 +1,124 @@
+#
+#    Copyright 2020, NTT Communications Corp.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+import os
+import sys
+import json
+import glob
+import time
+import pathlib
+import argparse
+from threading import Thread
+from socketserver import TCPServer
+from http.server import SimpleHTTPRequestHandler
+#from http.server import SimpleHTTPRequestHandler,ThreadingHTTPServer
+from pymisp import MISPEvent
+
+
+def save_event(outputdir, event):
+    try:
+        with open(os.path.join(outputdir, f'{event["Event"]["uuid"]}.json'), 'w') as f:
+            json.dump(event, f, indent=2)
+    except Exception as e:
+        print(e)
+        sys.exit('Could not create the event dump.')
+
+
+def save_manifest(outputdir, manifest):
+    try:
+        manifestFile = open(os.path.join(outputdir, 'manifest.json'), 'w')
+        manifestFile.write(json.dumps(manifest))
+        manifestFile.close()
+    except Exception as e:
+        print(e)
+        sys.exit('Could not create the manifest file.')
+
+
+def save_hashes(outputdir, hashes):
+    try:
+        with open(os.path.join(outputdir, 'hashes.csv'), 'w') as hashFile:
+            for element in hashes:
+                hashFile.write('{},{}\n'.format(element[0], element[1]))
+    except Exception as e:
+        print(e)
+        sys.exit('Could not create the quick hash lookup file.')
+
+
+def generate_feed(inputdir, outputdir):
+    manifest = {}
+    hashes = []
+    for file in glob.glob(os.path.join(inputdir, '*.json')):
+        print(file)
+        event = MISPEvent()
+        event.from_json(open(file).read())
+        event_feed = event.to_feed(with_meta=True)
+        
+        hashes += [[h, event.uuid] for h in event_feed['Event'].pop('_hashes')]
+        manifest.update(event_feed['Event'].pop('_manifest'))
+        save_event(outputdir, event_feed)
+
+    save_manifest(outputdir, manifest)
+    save_hashes(outputdir, hashes)
+
+def run_server(port):
+    with TCPServer(("", port), SimpleHTTPRequestHandler) as httpd:
+        httpd.serve_forever()
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        '-i', '--input', dest='inputdir', action='store', default=None,
+        help='Input directory where MISP json exists')
+    parser.add_argument(
+        '-o', '--output', dest='outputdir', action='store', default=None,
+        help='Output directory you want to store feed files')
+    parser.add_argument(
+        '-s', '--server', action='store_true',
+        help='If set, run as feed server')
+    parser.add_argument(
+        '-p', '--port', action='store', type=int, default=8080,
+        help='Port number of feed server')
+    args = parser.parse_args()
+
+    # convert to abs path
+    input_rel = pathlib.Path(args.inputdir)
+    input_abs = input_rel.resolve()
+
+    output_rel = pathlib.Path(args.outputdir)
+    output_abs = output_rel.resolve()
+
+    print(output_abs)
+    #generate_feed(args.inputdir, args.outputdir)
+    generate_feed(input_abs, output_abs)
+
+    if args.server:
+        os.chdir(output_abs)
+        thread = Thread(target=run_server, args=(args.port,), daemon=True)
+        #thread = Thread(target=run_server, args=(args.port, output_abs), daemon=True)
+        thread.start()
+        #with ThreadingHTTPServer(("", args.port), SimpleHTTPRequestHandler) as httpd:
+        #with TCPServer(("", args.port), SimpleHTTPRequestHandler) as httpd:
+        #    httpd.serve_forever()
+
+        event_files = set(os.listdir(input_abs))
+        while True:
+            current_files = set(os.listdir(input_abs))
+            if event_files != current_files:
+                generate_feed(input_abs, output_abs)
+                event_files = current_files
+            time.sleep(5)
+            pass

--- a/src/generate_feed.py
+++ b/src/generate_feed.py
@@ -24,7 +24,6 @@ import argparse
 from threading import Thread
 from socketserver import TCPServer
 from http.server import SimpleHTTPRequestHandler
-#from http.server import SimpleHTTPRequestHandler,ThreadingHTTPServer
 from pymisp import MISPEvent
 
 
@@ -101,18 +100,12 @@ if __name__ == '__main__':
     output_rel = pathlib.Path(args.outputdir)
     output_abs = output_rel.resolve()
 
-    print(output_abs)
-    #generate_feed(args.inputdir, args.outputdir)
     generate_feed(input_abs, output_abs)
 
     if args.server:
         os.chdir(output_abs)
         thread = Thread(target=run_server, args=(args.port,), daemon=True)
-        #thread = Thread(target=run_server, args=(args.port, output_abs), daemon=True)
         thread.start()
-        #with ThreadingHTTPServer(("", args.port), SimpleHTTPRequestHandler) as httpd:
-        #with TCPServer(("", args.port), SimpleHTTPRequestHandler) as httpd:
-        #    httpd.serve_forever()
 
         event_files = set(os.listdir(input_abs))
         while True:


### PR DESCRIPTION
clsoe #43 

Metemcyber でダウンロードしたスクリプトを、MISP のフィードサーバとして提供するためのスクリプト

- `generate_feed.py`
MISPの feed用ファイル `manifest.json` と `hashes.csv` を作成する
`-s` オプションを追加することで、http.server で指定ポートで待ち受けて作動する。 
`download` 配下のファイルに変更があったらMISPのfeed用ファイルを再度作成する.

- ` feed_downloaded_events.sh `
generate_feed.py を `-s` オプション付きで実行するシェルスクリプト