### PR TITLE
support multiple catalogs

### DIFF
--- a/setup_demo_catalog.in
+++ b/setup_demo_catalog.in
@@ -1,10 +1,15 @@
 1
-901
-
+900
+2
 n
+900
+4
+0
+901
 
 902
 @standalone_solver.py
+1
 20
 5a3a3aca-a210-497a-9715-452c950d210f
 OSINT - Rise of One More Mirai Worm Variant

--- a/src/eventlistener.py
+++ b/src/eventlistener.py
@@ -112,7 +112,9 @@ class BasicEventListener:
                     LOGGER.info(
                         'event %s: address=%s args=%s',
                         event['event'], event['address'], event['args'])
-                    value['callback'](event)
+
+                    Thread(target=value['callback'], args=[event]).start()
+
                 if self.__stopping:
                     break
             self.__lock.release()

--- a/src/seeker.py
+++ b/src/seeker.py
@@ -49,7 +49,9 @@ class Seeker():
         tasks = dict()
         for (task_id, token, solver, seeker, state) in reversed(raw_tasks):
             try:
-                title = catalog[token]['title']
+                title = [
+                    v for v in catalog.values() if v['token_address'] == token
+                    ][0]['title']
             except:
                 title = '(no information found on current catalog)'
             tasks[task_id] = {


### PR DESCRIPTION
複数のカタログを同時に扱えるように改修しました。
- 現行版の config.ini はそのまま読み込めます。
- カタログ操作はメニューの 900 です。-d オプションを付けないと表示されません。
- トークン発行などカタログに紐づく操作では、カタログ選択処理が追加してあります。
- カタログ選択が不可能な -m オプションでのトークン自動発行は、複数カタログが有効化されている場合は処理しません。メニューからの自動発行は可能です。
- カタログの有効・無効は、購入画面にトークンが出てくるか否かの違いです。無効にしても、購入画面に出てこない以外は機能しています。
- カタログの番号は追加した順序です。起動時、設定ファイルからロードした時点で決まるため、**番号が変わる** ことがあります。
- カタログごとの登録トークン数が1000未満であることを前提とした暫定実装が含まれます。代替策を検討する必要があります。