### PR TITLE
Topic/optimize metemctl config

### DIFF
--- a/src/metemctl_config.py
+++ b/src/metemctl_config.py
@@ -36,7 +36,11 @@ if __name__ == '__main__':
     config.read(CONFIG_INI_FILEPATH)
 
     # get key
-    if args['<key>']:
+    # print all option values
+    if args['--list']:
+        for option in config['general']:
+            print(option, ":", config['general'][option])
+    elif args['<key>']:
         print(config['general'][args['<key>']])
     # set key=value
     elif args['<key>'] and args['<value>']:
@@ -44,9 +48,5 @@ if __name__ == '__main__':
         with open(CONFIG_INI_FILEPATH, 'w') as fout:
             config.write(fout)
             print('update config.')
-    # print all option values
-    elif args['--list']:
-        for option in config['general']:
-            print(option, ":", config['general'][option])
     else:
         exit("%r is not valid in the config command. See 'metemctl config --help'.")

--- a/src/metemctl_config.py
+++ b/src/metemctl_config.py
@@ -32,29 +32,29 @@ CONFIG_INI_FILEPATH = "metemctl.ini"
 if __name__ == '__main__':
 
     args = docopt(__doc__)
-        
-    config = configparser.ConfigParser()
-    config.add_section('general')
-    config.read(CONFIG_INI_FILEPATH)
 
     if args['--section']:
         section = args['--section']
     else:
         section = 'general'
 
+    config = configparser.ConfigParser()
+    config.add_section(section)
+    config.read(CONFIG_INI_FILEPATH)
+
     # get value from key
     if args['get']:
         key = args['<key>']
-        if config.has_option('general', key):
-            print(config['general'][key])
+        if config.has_option(section, key):
+            print(config[section][key])
         else:
             print('Not a valid key: {0}'.format(key))
     # set key=value
     elif args['set']:
         key = args['<key>']
         value = args['<value>']
-        if config.has_option('general', key):
-            config.set('general', key, value)
+        if config.has_option(section, key):
+            config.set(section, key, value)
             with open(CONFIG_INI_FILEPATH, 'w') as fout:
                 config.write(fout)
                 print('update config.')

--- a/src/metemctl_config.py
+++ b/src/metemctl_config.py
@@ -29,7 +29,7 @@ CONFIG_INI_FILEPATH = "metemctl.ini"
 
 if __name__ == '__main__':
 
-    args = docopt(__doc__, help=True)
+    args = docopt(__doc__)
         
     config = configparser.ConfigParser()
     config.add_section('general')

--- a/src/metemctl_config.py
+++ b/src/metemctl_config.py
@@ -15,10 +15,11 @@
 #
 
 """
-usage: metemctl config <command> [<target>] [<value>]
+usage:
+    metemctl config [options] [<key>] [<value>]
 
-options:
-   -h, --help
+    -h, --help
+    -l, --list      Print option values within the general section
 
 """
 from docopt import docopt
@@ -29,35 +30,24 @@ CONFIG_INI_FILEPATH = "metemctl.ini"
 
 if __name__ == '__main__':
 
-    args = docopt(__doc__,
-                  options_first=True)
-    
+    args = docopt(__doc__, help=True)
+        
     config = configparser.ConfigParser()
     config.add_section('general')
     config.read(CONFIG_INI_FILEPATH)
-    
-    do = args['<command>']
-    target = args['<target>']
-    value = args['<value>']
 
-    # get command
-    if do == "get":
-        if target:
-            print(config['general'][target])
-        else:
-            print("Please specify the <target> in the 'get' command. See 'metemctl config --help'.")
-    # set command
-    elif do == "set" and target:
-        if target and value:
-            config.set('general', target, value)
-            with open(CONFIG_INI_FILEPATH, 'w') as fout:
-                config.write(fout)
-                print('update config.')
-        else:
-            print("Please specify the <target> and <value> in the 'set' command. See 'metemctl config --help'.")
-    # list command
-    elif do == "list":
+    # get key
+    if args['<key>']:
+        print(config['general'][args['<key>']])
+    # set key=value
+    elif args['<key>'] and args['<value>']:
+        config.set('general', args['<key>'], args['<value>'])
+        with open(CONFIG_INI_FILEPATH, 'w') as fout:
+            config.write(fout)
+            print('update config.')
+    # print all option values
+    elif args['--list']:
         for option in config['general']:
             print(option, ":", config['general'][option])
     else:
-        exit("%r is not valid in the config command. See 'metemctl config --help'." % args['<command>'])
+        exit("%r is not valid in the config command. See 'metemctl config --help'.")

--- a/src/metemctl_config.py
+++ b/src/metemctl_config.py
@@ -15,8 +15,7 @@
 #
 
 """
-usage:
-    metemctl config [options] [<key>] [<value>]
+usage: metemctl config [options] [<key>] [<value>]
 
     -h, --help
     -l, --list      Print option values within the general section

--- a/src/metemctl_config.py
+++ b/src/metemctl_config.py
@@ -46,7 +46,7 @@ if __name__ == '__main__':
         if config.has_option('general', key):
             # get value from key
             if not value:
-                print('Not a valid key: {0}'.format(key))
+                print(config['general'][key])
             # set key = value
             else:
                 config.set('general', key, value)

--- a/src/metemctl_config.py
+++ b/src/metemctl_config.py
@@ -15,10 +15,12 @@
 #
 
 """
-usage: metemctl config [options] [<key>] [<value>]
+usage:  metemctl config get [options] <key>
+        metemctl config set [options] <key> <value>
+        metemctl config list [options]
 
     -h, --help
-    -l, --list      Print option values within the general section
+    -s, --section <name>
 
 """
 from docopt import docopt
@@ -35,25 +37,32 @@ if __name__ == '__main__':
     config.add_section('general')
     config.read(CONFIG_INI_FILEPATH)
 
-    key = args['<key>']
-    value = args['<value>']
-    
-    # print all option values
-    if args['--list']:
-        for option in config['general']:
-            print(option, ":", config['general'][option])
-    elif key:
+    if args['--section']:
+        section = args['--section']
+    else:
+        section = 'general'
+
+    # get value from key
+    if args['get']:
+        key = args['<key>']
         if config.has_option('general', key):
-            # get value from key
-            if not value:
-                print(config['general'][key])
-            # set key = value
-            else:
-                config.set('general', key, value)
-                with open(CONFIG_INI_FILEPATH, 'w') as fout:
-                    config.write(fout)
-                    print('update config.')
+            print(config['general'][key])
         else:
             print('Not a valid key: {0}'.format(key))
+    # set key=value
+    elif args['set']:
+        key = args['<key>']
+        value = args['<value>']
+        if config.has_option('general', key):
+            config.set('general', key, value)
+            with open(CONFIG_INI_FILEPATH, 'w') as fout:
+                config.write(fout)
+                print('update config.')
+        else:
+            print('Not a valid key: {0}'.format(key))
+    # print all option values
+    elif args['list']:
+        for option in config[section]:
+            print(option, ":", config[section][option])
     else:
         exit("Options are not set. See 'metemctl config --help'.")

--- a/src/metemctl_config.py
+++ b/src/metemctl_config.py
@@ -35,18 +35,25 @@ if __name__ == '__main__':
     config.add_section('general')
     config.read(CONFIG_INI_FILEPATH)
 
-    # get key
+    key = args['<key>']
+    value = args['<value>']
+    
     # print all option values
     if args['--list']:
         for option in config['general']:
             print(option, ":", config['general'][option])
-    elif args['<key>']:
-        print(config['general'][args['<key>']])
-    # set key=value
-    elif args['<key>'] and args['<value>']:
-        config.set('general', args['<key>'], args['<value>'])
-        with open(CONFIG_INI_FILEPATH, 'w') as fout:
-            config.write(fout)
-            print('update config.')
+    elif key:
+        if config.has_option('general', key):
+            # get value from key
+            if not value:
+                print('Not a valid key: {0}'.format(key))
+            # set key = value
+            else:
+                config.set('general', key, value)
+                with open(CONFIG_INI_FILEPATH, 'w') as fout:
+                    config.write(fout)
+                    print('update config.')
+        else:
+            print('Not a valid key: {0}'.format(key))
     else:
-        exit("%r is not valid in the config command. See 'metemctl config --help'.")
+        exit("Options are not set. See 'metemctl config --help'.")


### PR DESCRIPTION
`metemctl config`のコードの使い勝手を変更しました。

```
設定値を取得: metemctl get <key> 
設定値を変更: metemctl set <key> <value>
generalセクションの設定値を表示: metemctl config list
[misp]セクションの設定値を表示: metemctl config list --section misp
[misp]セクションの設定値を取得: metemctl get --section misp <key> 
```