### PR TITLE
secret password from environment

### DIFF
--- a/src/metemctl.py
+++ b/src/metemctl.py
@@ -21,7 +21,7 @@ usage: metemctl [--version]
 options:
    -h, --help
 
-The most commonly used metmctl commands are:
+The most commonly used metemctl commands are:
    new        Create a new workflow
    config     Operate the config of metemctl
 
@@ -41,7 +41,7 @@ if __name__ == '__main__':
     argv = [args['<command>']] + args['<args>']
 
     #サブコマンドのリストを追加
-    if args['<command>'] in 'new config'.split():
+    if args['<command>'] in 'new config misp account'.split():
         exit(call(['python', 'src/metemctl_%s.py' % args['<command>']] + argv))
     elif args['<command>'] in ['help', None]:
         exit(call(['python', 'src/metemctl.py', '--help']))

--- a/src/metemctl_account.py
+++ b/src/metemctl_account.py
@@ -47,8 +47,11 @@ def decode_keyfile(filename, w3):
         with open(filename) as keyfile:
             enc_data = keyfile.read()
         address = Web3.toChecksumAddress(json.loads(enc_data)['address'])
-        print('You can also use an env METEMCTL_KEYFILE_PASSWORD.')
-        word = os.getenv('METEMCTL_KEYFILE_PASSWORD') or getpass('Enter password for keyfile:')
+        word = os.getenv('METEMCTL_KEYFILE_PASSWORD', "")
+        if word == "":
+            print('You can also use an env METEMCTL_KEYFILE_PASSWORD.')
+            word = getpass('Enter password for keyfile:')
+            
         private_key = w3.eth.account.decrypt(enc_data, word).hex()
         return address, private_key
     except Exception as err:

--- a/src/metemctl_account.py
+++ b/src/metemctl_account.py
@@ -47,7 +47,8 @@ def decode_keyfile(filename, w3):
         with open(filename) as keyfile:
             enc_data = keyfile.read()
         address = Web3.toChecksumAddress(json.loads(enc_data)['address'])
-        word = getpass('Enter password for keyfile:')
+        print('You can also use an env METEMCTL_KEYFILE_PASSWORD.')
+        word = os.getenv('METEMCTL_KEYFILE_PASSWORD') or getpass('Enter password for keyfile:')
         private_key = w3.eth.account.decrypt(enc_data, word).hex()
         return address, private_key
     except Exception as err:


### PR DESCRIPTION
環境変数からパスワードを参照できるようにmetemctl_account.pyを変更しました。
サブコマンド metemctl misp, metemctl account を実行できるようにmetemctl.pyを変更しました。

Co-authored-by: NISHINO Takuya <nitky@users.noreply.github.com>