### PR TITLE
cli impl with typer

### DIFF
--- a/metemcyber/cli/cli.py
+++ b/metemcyber/cli/cli.py
@@ -1,0 +1,72 @@
+import typer
+import configparser
+
+app = typer.Typer()
+
+misp_app = typer.Typer()
+app.add_typer(misp_app, name="misp")
+
+# コンフィグファイルの読み込み
+def read_config():
+    filename = "metemctl.ini"
+    config = configparser.ConfigParser()
+    config.read(filename) 
+    return config
+
+
+@app.callback()
+def app_callback(ctx: typer.Context):
+    ctx.meta['config'] = read_config()
+
+@app.command()
+def new():
+    typer.echo(f"new")
+
+@app.command()
+def catalog():
+    typer.echo(f"catallog")
+
+@app.command()
+def misp():
+    typer.echo(f"misp")
+
+@misp_app.command("open")
+def misp_open(ctx: typer.Context):
+    try:
+        misp_url = ctx.meta['config']['general']['misp_url']
+        typer.echo(misp_url)
+        typer.launch(misp_url)
+    except KeyError as e:
+        typer.echo(e, err=True)
+
+@app.command()
+def run():
+    typer.echo(f"run")
+
+@app.command()
+def check():
+    typer.echo(f"check")
+
+@app.command()
+def publish():
+    typer.echo(f"publish")
+
+@app.command()
+def account():
+    typer.echo(f"account")
+
+@app.command()
+def config():
+    typer.echo(f"config")
+
+@app.command()
+def contract():
+    typer.echo(f"contract")
+
+@app.command()
+def console():
+    typer.echo(f"console")
+
+
+if __name__ == "__main__":
+    app()

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -14,3 +14,4 @@ google-cloud-storage==1.32.0
 rusty-rlp
 docopt==0.6.2
 kedro==0.17.0
+typer==0.3.2


### PR DESCRIPTION
TyperによるCLIコマンドの実装。

コマンド動作方法（後にsetup.pyを書いてpip installできるようにする)
`python3 metemcyber/cli/cli.py misp open`