### PR TITLE
embed the signature in web3

### DIFF
--- a/metemcyber/cli/cli.py
+++ b/metemcyber/cli/cli.py
@@ -65,8 +65,8 @@ def app_callback(ctx: typer.Context):
     ctx.meta['config'] = config
 
     ether = Ether(config['general']['endpoint_url'])
-    eoa, _ = decode_keyfile(config['general']['keyfile'])
-    ctx.meta['account'] = Account(ether.web3, eoa, None)
+    eoa, pkey = decode_keyfile(config['general']['keyfile'])
+    ctx.meta['account'] = Account(ether.web3_with_signature(pkey), eoa)
 
 
 @app.command()

--- a/metemcyber/core/bc/account.py
+++ b/metemcyber/core/bc/account.py
@@ -18,7 +18,7 @@ from .wallet import Wallet
 
 
 class Account:
-    def __init__(self, web3, eoa, private_key):
+    def __init__(self, web3, eoa):
         self.eoa = eoa
         self.web3 = web3
         self.wallet = Wallet(web3, eoa)

--- a/metemcyber/core/bc/ether.py
+++ b/metemcyber/core/bc/ether.py
@@ -14,7 +14,7 @@
 #    limitations under the License.
 #
 
-from web3 import Account, Web3
+from web3 import Web3
 from web3.exceptions import ExtraDataLengthError
 from web3.middleware import (construct_sign_and_send_raw_middleware,
                              geth_poa_middleware)
@@ -34,7 +34,7 @@ class Ether:
 
         # 署名付きトランザクションの準備とcoinbaseアカウントの作成
         cssrm = construct_sign_and_send_raw_middleware(private_key)
-        account_id = Account.from_key(private_key)
+        account_id = self.web3.eth.account.from_key(private_key)
 
         # プライベート鍵の変数は今後使わないので明示的に削除
         del private_key

--- a/metemcyber/core/bc/ether.py
+++ b/metemcyber/core/bc/ether.py
@@ -36,7 +36,7 @@ class Ether:
         cssrm = construct_sign_and_send_raw_middleware(private_key)
         account_id = Account.from_key(private_key)
 
-        # プライベート鍵を明示的にメモリから削除
+        # プライベート鍵の変数は今後使わないので明示的に削除
         del private_key
 
         # ミドルウェアに署名付きトランザクションを設定

--- a/metemcyber/core/bc/ether.py
+++ b/metemcyber/core/bc/ether.py
@@ -14,10 +14,42 @@
 #    limitations under the License.
 #
 
-from web3 import Web3
+import web3
+from web3 import Account, Web3
+from web3.exceptions import ExtraDataLengthError
+from web3.middleware import (construct_sign_and_send_raw_middleware,
+                             geth_poa_middleware)
 from web3.providers.rpc import HTTPProvider
 
 
 class Ether:
     def __init__(self, endpoint):
         self.web3 = Web3(HTTPProvider(endpoint))
+        if self.web3.isConnected():
+            try:
+                self.web3.eth.getBlock('latest')
+            except ExtraDataLengthError:
+                self.web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+
+    def signature(self, private_key):
+
+        # 署名付きトランザクションの準備とcoinbaseアカウントの作成
+        cssrm = construct_sign_and_send_raw_middleware(private_key)
+        account_id = Account.from_key(private_key)
+
+        # プライベート鍵を明示的にメモリから削除
+        del private_key
+
+        # ミドルウェアに署名付きトランザクションを設定
+        # See https://github.com/ethereum/web3.py/blob/master/web3/datastructures.py
+        if 'sign_and_send_raw' in self.web3.middleware_onion._queue:
+            self.web3.middleware_onion.replace('sign_and_send_raw', cssrm)
+        else:
+            self.web3.middleware_onion.add(cssrm, 'sign_and_send_raw')
+
+        # coinbaseとしてアカウントを設定
+        self.web3.eth.defaultAccount = account_id
+
+    def web3_with_signature(self, private_key):
+        self.signature(private_key)
+        return self.web3

--- a/metemcyber/core/bc/ether.py
+++ b/metemcyber/core/bc/ether.py
@@ -14,7 +14,6 @@
 #    limitations under the License.
 #
 
-import web3
 from web3 import Account, Web3
 from web3.exceptions import ExtraDataLengthError
 from web3.middleware import (construct_sign_and_send_raw_middleware,


### PR DESCRIPTION
Web3.pyのミドルウェアの中に、トランザクション用の署名情報を埋め込むことにしました。
スマートコントラクトに対する操作は、署名付きweb3オブジェクトを用いて行う予定です。