### PR TITLE
add contract classes

### DIFF
--- a/metemcyber/core/bc/contract.py
+++ b/metemcyber/core/bc/contract.py
@@ -1,0 +1,154 @@
+#
+#    Copyright 2020, NTT Communications Corp.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+import logging
+import json
+import os
+from web3 import Web3
+
+LOGGER = logging.getLogger('common')
+GASLOG = logging.getLogger('gaslog')
+
+
+class Contract():
+
+    deployed_libs = dict() # {name: {address:x, placeholder:x}}
+    contract_interface = dict()  # shold be overridden by sub class
+    contract_id = None  # should be overridden by subclass
+
+    def __init__(self, web3):
+        assert web3
+        self.web3 = web3  # should be initialized with EOA & private key
+        self.contract = None  # initialized by get()
+
+    @property
+    def address(self):
+        return self.contract.address if self.contract else None
+
+    def new(self, *args, **kwargs):
+        assert self.web3
+        # pylint: disable=protected-access
+        address = self.__class__.__deploy(self.web3, *args, **kwargs)
+        return self.get(address)
+
+    def get(self, address):
+        assert self.web3
+        assert address
+        if not Web3.isChecksumAddress(address):
+            raise Exception('Invalid address: {}'.format(address))
+        # pylint: disable=protected-access
+        self.__class__.__load()
+        self.contract = self.web3.eth.contract(
+            address=address, abi=self.__class__.contract_interface['abi'])
+        return self
+
+    @classmethod
+    def register_library(cls, address, placeholder=''):
+        #   for detail of placeholder, see below.
+        #   https://solidity.readthedocs.io/en/latest/using-the-compiler.html
+        assert address
+        assert cls.contract_id
+        if cls.contract_id in Contract.deployed_libs.keys():
+            raise Exception('already registered')
+        if not placeholder:
+            keccak = Web3.keccak(text=cls.contract_id).hex()[2:] # cut 0x
+            placeholder = '__$' + keccak[:34] + '$__'
+        Contract.deployed_libs[cls.contract_id] = {
+            'address': address, 'placeholder': placeholder}
+        LOGGER.debug(Contract.deployed_libs)
+        return placeholder
+
+    @classmethod
+    def __load(cls):
+        if not cls.contract_id:
+            raise Exception('contract_id is not defined: {}'.format(cls))
+        if cls.contract_interface:
+            return
+
+        # contract_id is "<SourceFilename>:<ContractName>"
+        contract_src = cls.contract_id.split(':')[0]
+        contract_basename = os.path.splitext(contract_src)[0]
+        contract_interface = dict()
+        try:
+            # contractsのcombined.jsonが配置されているパス
+            work_dir = os.path.dirname(os.path.abspath(__file__))
+            contractsdata_dir = os.path.join(work_dir, 'contracts_data')  # FIXME
+
+            # combined.json should be generated with
+            #   % solc --combined-json bin,metadata xxx.sol \
+            #     > contracts_data/xxx.combined.json
+            combined_file = os.path.join(
+                contractsdata_dir, contract_basename + '.combined.json')
+            with open(combined_file, 'r') as fin:
+                combined_json = \
+                    json.loads(fin.read())['contracts'][cls.contract_id]
+
+            # Metadata (json nested in json) の追加
+            contract_metadata = json.loads(combined_json['metadata'])
+            contract_interface['abi'] = contract_metadata['output']['abi']
+
+            # バイナリデータの追加
+            bytecode = combined_json['bin']
+            for lib in Contract.deployed_libs.values():
+                ## Oops, link_code@solcx does not work well...
+                ## WORKAROUND: replace placeholder with address manually.
+                bytecode = bytecode.replace(
+                    lib['placeholder'], lib['address'][2:])  # cut 0x
+            contract_interface['bin'] = bytecode
+
+        except (FileNotFoundError, KeyError) as err:
+            raise Exception(
+                'Contract data load failed: {}'.format(cls.contract_id)) \
+                from err
+        cls.contract_interface = contract_interface
+
+    @classmethod
+    def __deploy(cls, web3, *args, **kwargs):
+        # コントラクトのチェーンへのデプロイ
+        if not cls.contract_interface:
+            cls.__load()
+        if not web3:
+            raise Exception('missing web3')
+
+        # constructorに引数が必要な場合は指定
+        if args or kwargs:
+            func = web3.eth.contract(
+                abi=cls.contract_interface['abi'],
+                bytecode=cls.contract_interface['bin']).\
+                    constructor(*args, **kwargs)
+        else:
+            func = web3.eth.contract(
+                abi=cls.contract_interface['abi'],
+                bytecode=cls.contract_interface['bin']).\
+                    constructor()
+
+        tx_hash = func.transact()
+        tx_receipt = web3.eth.waitForTransactionReceipt(tx_hash)
+        cls.gaslog('deploy', tx_receipt)
+        if tx_receipt['status'] != 1:
+            raise ValueError(
+                'Contract deploy failed: {}'.format(cls.contract_id))
+
+        return tx_receipt['contractAddress']
+
+    def event_filter(self, event_name, **kwargs):
+        event = getattr(self.contract.events, event_name)
+        return event.createFilter(**kwargs)
+
+    @classmethod
+    def gaslog(cls, func, tx_receipt):
+        GASLOG.info(
+            '%s.%s: gasUsed=%d', cls.__name__, func, tx_receipt['gasUsed'])

--- a/metemcyber/core/bc/contracts_data
+++ b/metemcyber/core/bc/contracts_data
@@ -1,0 +1,1 @@
+../../../src/contracts_data

--- a/metemcyber/core/bc/cti_broker.py
+++ b/metemcyber/core/bc/cti_broker.py
@@ -1,0 +1,53 @@
+#
+#    Copyright 2020, NTT Communications Corp.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+import logging
+from .contract import Contract
+
+LOGGER = logging.getLogger('common')
+
+
+class CTIBroker(Contract):
+    contract_interface = dict()
+    contract_id = 'CTIBroker.sol:CTIBroker'
+
+    def consign_token(self, catalog, token, amount):
+        func = self.contract.functions.consignToken(catalog, token, amount)
+        tx_hash = func.transact()
+        tx_receipt = self.web3.eth.waitForTransactionReceipt(tx_hash)
+        self.gaslog('consignToken', tx_receipt)
+        if tx_receipt['status'] != 1:
+            raise ValueError('consignToken: transaction failed')
+
+    def takeback_token(self, catalog, token, amount):
+        func = self.contract.functions.takebackToken(catalog, token, amount)
+        tx_hash = func.transact()
+        tx_receipt = self.web3.eth.waitForTransactionReceipt(tx_hash)
+        self.gaslog('takebackToken', tx_receipt)
+        if tx_receipt['status'] != 1:
+            raise ValueError('takebackToken: transaction failed')
+
+    def buy_token(self, catalog, token, wei, allow_cheaper=False):
+        func = self.contract.functions.buyToken(catalog, token, allow_cheaper)
+        tx_hash = func.transact({'value': wei})
+        tx_receipt = self.web3.eth.waitForTransactionReceipt(tx_hash)
+        self.gaslog('buyToken', tx_receipt)
+        if tx_receipt['status'] != 1:
+            raise ValueError('buyToken: transaction failed')
+
+    def get_amounts(self, catalog, tokens):
+        func = self.contract.functions.getAmounts(catalog, tokens)
+        return func.call()

--- a/metemcyber/core/bc/cti_catalog.py
+++ b/metemcyber/core/bc/cti_catalog.py
@@ -1,0 +1,132 @@
+#
+#    Copyright 2020, NTT Communications Corp.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+import logging
+from .contract import Contract
+
+LOGGER = logging.getLogger('common')
+
+
+class CTICatalog(Contract):
+    contract_interface = dict()
+    contract_id = 'CTICatalog.sol:CTICatalog'
+
+    def get_owner(self):
+        func = self.contract.functions.getOwner()
+        return func.call()
+
+    def publish_cti(self, producer_address, token_address):
+        func = self.contract.functions.publishCti(
+            producer_address, token_address)
+        tx_hash = func.transact()
+        tx_receipt = self.web3.eth.waitForTransactionReceipt(tx_hash)
+        self.gaslog('publishCti', tx_receipt)
+        if tx_receipt['status'] != 1:
+            raise ValueError('Transaction failed: publishCti')
+
+    def register_cti(self, token_address, uuid, title, price, operator):
+        func = self.contract.functions.registerCti(
+            token_address, uuid, title, price, operator)
+        tx_hash = func.transact()
+        tx_receipt = self.web3.eth.waitForTransactionReceipt(tx_hash)
+        self.gaslog('registerCti', tx_receipt)
+        if tx_receipt['status'] != 1:
+            raise ValueError('Transaction failed: registerCti')
+
+    def modify_cti(self, token_address, uuid, title, price, operator):
+        func = self.contract.functions.modifyCti(
+            token_address, uuid, title, price, operator)
+        tx_hash = func.transact()
+        tx_receipt = self.web3.eth.waitForTransactionReceipt(tx_hash)
+        self.gaslog('modifyCti', tx_receipt)
+        if tx_receipt['status'] != 1:
+            raise ValueError('Transaction failed: modifyCti')
+
+    def unregister_cti(self, token_address):
+        func = self.contract.functions.unregisterCti(token_address)
+        tx_hash = func.transact()
+        tx_receipt = self.web3.eth.waitForTransactionReceipt(tx_hash)
+        self.gaslog('unregisterCti', tx_receipt)
+        if tx_receipt['status'] != 1:
+            raise ValueError('Transaction failed: unregisterCti')
+
+    def list_token_uris(self):
+        func = self.contract.functions.listTokenURIs()
+        tokens = func.call()
+        return [t for t in tokens if t != '']
+
+    def get_cti_info(self, token_address):
+        func = self.contract.functions.getCtiInfo(token_address)
+        token_id, owner, uuid, title, price, operator, likecount = func.call()
+        return token_id, owner, uuid, title, price, operator, likecount
+
+    def like_cti(self, token_address):
+        func = self.contract.functions.likeCti(token_address)
+        tx_hash = func.transact()
+        tx_receipt = self.web3.eth.waitForTransactionReceipt(tx_hash)
+        self.gaslog('likeCti', tx_receipt)
+        if tx_receipt['status'] != 1:
+            raise ValueError('Transaction failed: likeCti')
+
+    def get_like_event(self, search_blocks=1000):
+        # 最大search_blocks数だけ、CtiLiked eventを取得して返す
+        from_block = max(
+            self.web3.eth.blockNumber - search_blocks + 1, 0)
+        # filterの作成
+        event_filter = self.event_filter('CtiLiked', fromBlock=from_block)
+        # filterに合致するeventの取得
+        event_logs = event_filter.get_all_entries()
+        return event_logs
+
+    def is_private(self):
+        func = self.contract.functions.isPrivate()
+        return func.call()
+
+    def set_private(self):
+        func = self.contract.functions.setPrivate()
+        tx_hash = func.transact()
+        tx_receipt = self.web3.eth.waitForTransactionReceipt(tx_hash)
+        self.gaslog('setPrivate', tx_receipt)
+        if tx_receipt['status'] != 1:
+            raise ValueError('Transaction failed: setPrivate')
+
+    def set_public(self):
+        func = self.contract.functions.setPublic()
+        tx_hash = func.transact()
+        tx_receipt = self.web3.eth.waitForTransactionReceipt(tx_hash)
+        self.gaslog('setPublic', tx_receipt)
+        if tx_receipt['status'] != 1:
+            raise ValueError('Transaction failed: setPublic')
+
+    def authorize_user(self, eoa_address):
+        func = self.contract.functions.authorizeUser(eoa_address)
+        tx_hash = func.transact()
+        tx_receipt = self.web3.eth.waitForTransactionReceipt(tx_hash)
+        self.gaslog('authorizeUser', tx_receipt)
+        if tx_receipt['status'] != 1:
+            raise ValueError('Transaction failed: authorizeUser')
+
+    def revoke_user(self, eoa_address):
+        func = self.contract.functions.revokeUser(eoa_address)
+        tx_hash = func.transact()
+        tx_receipt = self.web3.eth.waitForTransactionReceipt(tx_hash)
+        self.gaslog('revokeUser', tx_receipt)
+        if tx_receipt['status'] != 1:
+            raise ValueError('Transaction failed: revokeUser')
+
+    def show_authorized_users(self):
+        func = self.contract.functions.showAuthorizedUsers()
+        return func.call()

--- a/metemcyber/core/bc/cti_operator.py
+++ b/metemcyber/core/bc/cti_operator.py
@@ -1,0 +1,101 @@
+#
+#    Copyright 2020, NTT Communications Corp.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+import logging
+from .contract import Contract
+
+LOGGER = logging.getLogger('common')
+
+
+class CTIOperator(Contract):
+    contract_interface = dict()
+    contract_id = 'CTIOperator.sol:CTIOperator'
+
+    def history(self, token_address, limit, offset=0):
+        func = self.contract.functions.history(token_address, limit, offset)
+        return func.call()
+
+    def set_recipient(self):
+        func = self.contract.functions.recipientFor(self.address)
+        tx_hash = func.transact()
+        tx_receipt = self.web3.eth.waitForTransactionReceipt(tx_hash)
+        self.gaslog('recipientFor', tx_receipt)
+        if tx_receipt['status'] != 1:
+            raise ValueError('Transaction failed: recipientFor')
+
+    def register_recipient(self):
+        func = self.contract.functions.registerRecipient(self.address)
+        tx_hash = func.transact()
+        tx_receipt = self.web3.eth.waitForTransactionReceipt(tx_hash)
+        self.gaslog('registerRecipient', tx_receipt)
+        if tx_receipt['status'] != 1:
+            raise ValueError('Transaction failed: registerRecipient')
+
+    def register_tokens(self, token_addresses):
+        func = self.contract.functions.register(token_addresses)
+        tx_hash = func.transact()
+        tx_receipt = self.web3.eth.waitForTransactionReceipt(tx_hash)
+        self.gaslog('register', tx_receipt)
+        if tx_receipt['status'] != 1:
+            raise ValueError('Transaction failed: register')
+        LOGGER.info('register succeeded: %s', token_addresses)
+
+    def unregister_tokens(self, token_addresses):
+        func = self.contract.functions.unregister(token_addresses)
+        tx_hash = func.transact()
+        tx_receipt = self.web3.eth.waitForTransactionReceipt(tx_hash)
+        self.gaslog('unregister', tx_receipt)
+        if tx_receipt['status'] != 1:
+            raise ValueError('Transaction failed: unregister')
+        LOGGER.info('unregister succeeded: %s', token_addresses)
+
+    def accept_task(self, task_id):
+        func = self.contract.functions.accepted(task_id)
+        tx_hash = func.transact()
+        tx_receipt = self.web3.eth.waitForTransactionReceipt(tx_hash)
+        self.gaslog('accepted', tx_receipt)
+        if tx_receipt['status'] != 1:
+            raise ValueError('Transaction failed: accepted')
+        LOGGER.info('accept_task succeeded: %s', task_id)
+
+    def finish_task(self, task_id, data=''):
+        func = self.contract.functions.finish(task_id, data)
+        tx_hash = func.transact()
+        tx_receipt = self.web3.eth.waitForTransactionReceipt(tx_hash)
+        self.gaslog('finish', tx_receipt)
+        if tx_receipt['status'] != 1:
+            raise ValueError('Transaction failed: finish')
+        LOGGER.info('finish_task succeeded: %s', task_id)
+
+    def cancel_challenge(self, task_id):
+        func = self.contract.functions.cancelTask(task_id)
+        tx_hash = func.transact()
+        tx_receipt = self.web3.eth.waitForTransactionReceipt(tx_hash)
+        self.gaslog('cancelTask', tx_receipt)
+        if tx_receipt['status'] != 1:
+            raise ValueError('Transaction failed: cancelTask')
+
+    def reemit_pending_tasks(self, tokens):
+        func = self.contract.functions.reemitPendingTasks(tokens)
+        tx_hash = func.transact()
+        tx_receipt = self.web3.eth.waitForTransactionReceipt(tx_hash)
+        self.gaslog('reemitPendingTasks', tx_receipt)
+        if tx_receipt['status'] != 1:
+            raise ValueError('Transaction failed: reemitPendingTasks')
+
+    def check_registered(self, token_addresses):
+        func = self.contract.functions.checkRegistered(token_addresses)
+        return func.call()

--- a/metemcyber/core/bc/cti_token.py
+++ b/metemcyber/core/bc/cti_token.py
@@ -1,0 +1,64 @@
+#
+#    Copyright 2020, NTT Communications Corp.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+import logging
+from web3 import Web3
+from .contract import Contract
+
+LOGGER = logging.getLogger('common')
+
+
+class CTIToken(Contract):
+    contract_interface = dict()
+    contract_id = 'CTIToken.sol:CTIToken'
+
+    def balance_of(self, account_id):
+        func = self.contract.functions.balanceOf(account_id)
+        return func.call()
+
+    def send_token(self, dest, amount=1, data=''):
+        bdata = Web3.toBytes(text=data)
+        func = self.contract.functions.send(dest, amount, bdata)
+        tx_hash = func.transact()
+        tx_receipt = self.web3.eth.waitForTransactionReceipt(tx_hash)
+        self.gaslog('send', tx_receipt)
+        if tx_receipt['status'] != 1:
+            raise ValueError('Transaction failed: send')
+
+    def burn_token(self, amount, data=''):
+        bdata = Web3.toBytes(text=data)
+        func = self.contract.functions.burn(amount, bdata)
+        tx_hash = func.transact()
+        tx_receipt = self.web3.eth.waitForTransactionReceipt(tx_hash)
+        self.gaslog('burn', tx_receipt)
+        if tx_receipt['status'] != 1:
+            raise ValueError('Transaction failed: burn')
+
+    def authorize_operator(self, operator):
+        func = self.contract.functions.authorizeOperator(operator)
+        tx_hash = func.transact()
+        tx_receipt = self.web3.eth.waitForTransactionReceipt(tx_hash)
+        self.gaslog('authorizeOperator', tx_receipt)
+        if tx_receipt['status'] != 1:
+            raise ValueError('Transaction failed: authorizeOperator')
+
+    def revoke_operator(self, operator):
+        func = self.contract.functions.revokeOperator(operator)
+        tx_hash = func.transact()
+        tx_receipt = self.web3.eth.waitForTransactionReceipt(tx_hash)
+        self.gaslog('revokeOperator', tx_receipt)
+        if tx_receipt['status'] != 1:
+            raise ValueError('Transaction failed: revokeOperator')

--- a/metemcyber/core/bc/metemcyber_util.py
+++ b/metemcyber/core/bc/metemcyber_util.py
@@ -1,0 +1,22 @@
+#
+#    Copyright 2020, NTT Communications Corp.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+from .contract import Contract
+
+
+class MetemcyberUtil(Contract):
+    contract_interface = dict()
+    contract_id = 'MetemcyberUtil.sol:MetemcyberUtil'


### PR DESCRIPTION
コントラクトクラスを移植しました。
- ログ周りは未調整です。
- combined_json のパスは暫定的なので、とりあえず使えるようにシンボリックリンクを commit してあります。

```
Usage: 
  cti_token = CTIToken(web3).get(address)
or
  cti_token = CTIToken(web3).new(... deploy args ...)
  address = cti_token.address
```