### PR TITLE
support setuptools

### DIFF
--- a/metemcyber/__init__.py
+++ b/metemcyber/__init__.py
@@ -1,0 +1,1 @@
+__version__ = "0.1.0-alpha"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,30 @@
+#
+#    Copyright 2021, NTT Communications Corp.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+# See https://setuptools.readthedocs.io/en/latest/setuptools.html
+
+[metadata]
+name = metemcyber
+version = attr: metemcyber.__version__
+license_file = LICENSE
+author = NTT Communications Corporation
+url = https://github.com/nttcom/metemcyber
+
+[options.entry_points]
+console_scripts =
+    metemctl = metemcyber.cli.cli:app
+
+

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,23 @@
+#
+#    Copyright 2021, NTT Communications Corp.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+
+from setuptools import setup
+
+with open('requirements/common.txt') as requirements_file:
+    requirements = requirements_file.read().splitlines()
+
+setup(install_requires=requirements)


### PR DESCRIPTION
setuptoolsでのインストールに対応しました。
`pip install -e .`でパッケージのインストールが可能になります。

同時にCLIツールの`metemctl`もインストールされるので、`metemctl --help`コマンドによる動作確認をお願いいたします。