### PR TITLE
enhance account-info

### DIFF
--- a/metemcyber/cli/cli.py
+++ b/metemcyber/cli/cli.py
@@ -25,6 +25,9 @@ from web3.auto import w3
 from metemcyber.core.bc.ether import Ether
 from metemcyber.core.logger import get_logger
 from metemcyber.core.bc.account import Account
+from metemcyber.core.bc.catalog_manager import CatalogManager
+from metemcyber.core.bc.catalog import Catalog
+from metemcyber.core.bc.token import Token
 
 app = typer.Typer()
 

--- a/metemcyber/core/bc/catalog.py
+++ b/metemcyber/core/bc/catalog.py
@@ -1,0 +1,137 @@
+#
+#    Copyright 2021, NTT Communications Corp.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+from typing import Optional, Dict
+from eth_typing import ChecksumAddress
+from web3 import Web3
+from .cti_catalog import CTICatalog
+
+
+class TokenInfo():
+    def __init__(self):
+        self.address = None
+        self.token_id = None
+        self.owner = None
+        self.uuid = None
+        self.title = None
+        self.price = None
+        self.operator = None
+        self.like_count = None
+
+
+class CatalogInfo():
+    def __init__(self):
+        self.address = None
+        self.catalog_id = None
+        self.owner = None
+        self.private = None
+        self.tokens: Dict[ChecksumAddress, TokenInfo] = {}
+
+    def tokeninfo_by_address(
+            self, address: ChecksumAddress) -> Optional[TokenInfo]:
+        return self.tokens.get(address)
+
+    def tokeninfo_by_id(self, token_id: int) -> Optional[TokenInfo]:
+        tmp = [info for info in self.tokens.values()
+                if info.token_id == token_id]
+        return tmp[0] if tmp else None
+
+
+class Catalog():
+    __addressed_catalogs: Dict[ChecksumAddress, CatalogInfo] = {}
+
+    @property
+    def _catalogs_by_address(self):
+        return Catalog.__addressed_catalogs
+
+    @property
+    def _catalogs_by_id(self):
+        return {info['catalog_id']: info
+            for info in Catalog.__addressed_catalogs.values()}
+
+    def __init__(self, web3: Web3) -> None:
+        self.web3: Web3 = web3
+        self.address: Optional[ChecksumAddress] = None
+        self.catalog_id: int = 0
+        self.owner: Optional[ChecksumAddress] = None
+        self.private: Optional[bool] = None
+        self.tokens: Dict[ChecksumAddress, TokenInfo] = {}
+
+    def get(self, address: ChecksumAddress) -> 'Catalog':
+        assert self.web3
+        self.address = address
+        self._sync_catalog()
+        return self
+
+    def get_by_id(self, catalog_id: int) -> 'Catalog':
+        return self.get(self._catalogs_by_id()[catalog_id].address)
+
+    def new(self, private: bool) -> 'Catalog':
+        assert self.web3
+        cti_catalog = CTICatalog(self.web3).new(private)
+        return self.get(cti_catalog.address)
+
+    def uncache(self, entire: bool = False) -> None:
+        if entire:
+            del Catalog.__addressed_catalogs
+            Catalog.__addressed_catalogs = {}
+        else:
+            assert self.address
+            if self.address in Catalog.__addressed_catalogs.keys():
+                del Catalog.__addressed_catalogs[self.address]
+
+    @staticmethod
+    def _gen_catalog_id() -> int:
+        return max([val.catalog_id for val
+                in Catalog.__addressed_catalogs.values()] + [0]
+            ) + 1
+
+    def _sync_catalog(self) -> None:
+        assert self.web3
+        assert self.address
+        cinfo = self._catalogs_by_address.get(self.address)
+        if not cinfo:
+            cinfo = CatalogInfo()
+            cinfo.address = self.address
+            cinfo.catalog_id = self._gen_catalog_id()
+            Catalog.__addressed_catalogs[self.address] = cinfo
+            cti_catalog = CTICatalog(self.web3).get(self.address)
+            cinfo.owner = cti_catalog.get_owner()
+            cinfo.private = cti_catalog.is_private()
+            for taddr in cti_catalog.list_token_uris():
+                tinfo = TokenInfo()
+                tid, owner, uuid, title, price, operator, lcount = \
+                    cti_catalog.get_cti_info(taddr)
+                tinfo.address = taddr
+                tinfo.token_id = tid
+                tinfo.owner = owner
+                tinfo.uuid = uuid
+                tinfo.title = title
+                tinfo.price = price
+                tinfo.operator = operator
+                tinfo.like_count = lcount
+                cinfo.tokens[taddr] = tinfo
+        self.catalog_id = cinfo.catalog_id
+        self.owner = cinfo.owner
+        self.private = cinfo.private
+        self.tokens = cinfo.tokens
+
+    def get_tokeninfo(self, address: ChecksumAddress) -> Optional[TokenInfo]:
+        return self.tokens.get(address)
+
+    def get_tokeninfo_by_id(self, token_id: int) -> Optional[TokenInfo]:
+        cinfo = self._catalogs_by_address.get(self.address)
+        return cinfo.tokeninfo_by_id(token_id)

--- a/metemcyber/core/bc/catalog_manager.py
+++ b/metemcyber/core/bc/catalog_manager.py
@@ -1,0 +1,66 @@
+#
+#    Copyright 2021, NTT Communications Corp.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+from typing import Optional, List, Set, Dict
+from eth_typing import ChecksumAddress
+from web3 import Web3
+from .catalog import Catalog
+
+
+class CatalogManager():
+    def __init__(self, web3: Web3) -> None:
+        #                   catalog_address  catalog_id
+        self.web3: Web3 = web3
+        self.catalogs: Dict[ChecksumAddress, int] = {}
+        self.actives: Set[ChecksumAddress] = set()
+
+    def add(self, addresses: List[ChecksumAddress], activate=False) -> None:
+        for address in addresses:
+            catalog = Catalog(self.web3).get(address)
+            self.catalogs[address] = catalog.catalog_id
+            if activate:
+                self.actives.add(address)
+
+    def remove(self, addresses: List[ChecksumAddress]) -> None:
+        for address in addresses:
+            del self.catalogs[address]
+            self.actives.discard(address)
+
+    def activate(self, addresses: List[ChecksumAddress]) -> None:
+        for address in addresses:
+            assert address in self.catalogs.keys()
+            self.actives.add(address)
+
+    def deactivate(self, addresses: List[ChecksumAddress]) -> None:
+        for address in addresses:
+            assert address in self.catalogs.keys()
+            self.actives.discard(address)
+
+    def _catalogs(self, active: Optional[bool]) -> Dict[ChecksumAddress, int]:
+        return {addr: cid for addr, cid in self.catalogs.items()
+            if active in (None, addr in self.actives)}
+
+    @property
+    def active_catalogs(self) -> Dict[ChecksumAddress, int]:
+        return self._catalogs(active=True)
+
+    @property
+    def reserved_catalogs(self) -> Dict[ChecksumAddress, int]:
+        return self._catalogs(active=False)
+
+    @property
+    def all_catalogs(self) -> Dict[ChecksumAddress, int]:
+        return self._catalogs(active=None)

--- a/metemcyber/core/bc/token.py
+++ b/metemcyber/core/bc/token.py
@@ -1,0 +1,70 @@
+#
+#    Copyright 2021, NTT Communications Corp.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+from typing import Optional, List, Dict
+from eth_typing import ChecksumAddress
+from web3 import Web3
+from .cti_token import CTIToken
+
+
+class Token():
+    #                token address         eoa address      balance
+    tokens_map: Dict[ChecksumAddress, Dict[ChecksumAddress, int]] = {}
+
+    def __init__(self, web3: Web3) -> None:
+        self.web3: Web3 = web3
+        self.address: Optional[ChecksumAddress] = None
+
+    def get(self, address: ChecksumAddress) -> 'Token':
+        self.address = address
+        return self
+
+    def new(self, initial_supply: int,
+            default_operators: List[ChecksumAddress]) -> 'Token':
+        assert self.web3
+        cti_token = CTIToken(self.web3).new(initial_supply, default_operators)
+        return self.get(cti_token.address)
+
+    def uncache(self, entire: bool = False) -> None:
+        if entire:
+            del Token.tokens_map
+            Token.tokens_map = {}
+        else:
+            assert self.address
+            if self.address in Token.tokens_map.keys():
+                del Token.tokens_map[self.address]
+
+    def balance_of(self, target: ChecksumAddress) -> int:
+        assert self.address
+        if self.address not in Token.tokens_map.keys():
+            Token.tokens_map[self.address] = {}
+        if target not in Token.tokens_map[self.address].keys():
+            cti_token = CTIToken(self.web3).get(self.address)
+            balance = cti_token.balance_of(target)
+            Token.tokens_map[self.address][target] = balance
+        return Token.tokens_map[self.address][target]
+
+    def send(self, dest: ChecksumAddress, amount: int, data: str = '') -> None:
+        assert self.web3
+        assert self.address
+        cti_token = CTIToken(self.web3).get(self.address)
+        cti_token.send_token(dest, amount, data)
+
+    def burn(self, amount: int, data: str = '') -> None:
+        assert self.web3
+        assert self.address
+        cti_token = CTIToken(self.web3).get(self.address)
+        cti_token.burn_token(amount, data)


### PR DESCRIPTION
account info で所有トークンを表示するように改修しました。
- metemctl.ini に `[catalog]` セクションを追加し、`actives = <catalog_address>,...` を追加してください。
- 上記設定を含め、カタログ操作機能は未実装です。
- Catalog, Token のクラス変数にカタログおよびトークンのbalance情報をキャッシュしています。（単発コマンドではほぼ無関係ですが）イベントリスナから更新するケースを想定した設計です。
- 現状では Catalog インスタンスのプロパティに情報をコピーしていますが、これは撤廃したほうがよいかもしれません。