### PR TITLE
add catalog control

### DIFF
--- a/metemcyber/core/bc/catalog_manager.py
+++ b/metemcyber/core/bc/catalog_manager.py
@@ -64,3 +64,8 @@ class CatalogManager():
     @property
     def all_catalogs(self) -> Dict[ChecksumAddress, int]:
         return self._catalogs(active=None)
+
+    def get_catalog_by_id(self, catalog_id: int) -> ChecksumAddress:
+        tmp = [caddr for caddr, cid in self.catalogs.items()
+            if cid == catalog_id]
+        return tmp[0] if tmp else None


### PR DESCRIPTION
カタログ操作コマンドを追加しました。
- list で現状表示、add, remove, activate, deactivate で操作です。
- remove, activate, deactivate には、アドレスでなくカタログIDで指定するオプション --by-id があります。（--no-by-id とか要らないんだけど外せないのかしらん）
