### PR TITLE
Topic/enhance ix commands

### DIFF
--- a/metemcyber/cli/cli.py
+++ b/metemcyber/cli/cli.py
@@ -441,10 +441,10 @@ def _ix_parse_token_index(ctx: typer.Context, token_index: str
 
 @ix_app.command('list')
 def ix_list(ctx: typer.Context,
-            mine: bool = typer.Option(True, help='show tokens published by me'),
+            mine: bool = typer.Option(True, help='show tokens published by you'),
             mine_only: bool = typer.Option(False),
             soldout: bool = typer.Option(False, help='show soldout tokens'),
-            own: bool = typer.Option(True, help='show tokens I own'),
+            own: bool = typer.Option(True, help='show tokens you own'),
             own_only: bool = typer.Option(False)):
     logger = getLogger()
     try:

--- a/metemcyber/core/bc/broker.py
+++ b/metemcyber/core/bc/broker.py
@@ -102,10 +102,12 @@ class Broker():
         cti_token = CTIToken(self.web3).get(token)
         cti_broker = CTIBroker(self.web3).get(self.address)
         cti_token.authorize_operator(self.address)
-        cti_broker.consign_token(catalog, token, amount)
-        cti_token.revoke_operator(self.address)
-        self.uncache(catalog, token)
-        Token(self.web3).get(token).uncache()  # FIXME: should I?
+        try:
+            cti_broker.consign_token(catalog, token, amount)
+            self.uncache(catalog, token)
+            Token(self.web3).get(token).uncache()  # FIXME: should I?
+        finally:
+            cti_token.revoke_operator(self.address)
 
     def takeback(self, catalog: ChecksumAddress, token: ChecksumAddress,
                  amount: int) -> None:

--- a/metemcyber/core/bc/catalog.py
+++ b/metemcyber/core/bc/catalog.py
@@ -15,6 +15,7 @@
 #
 
 from typing import Dict, Optional
+from uuid import UUID
 
 from eth_typing import ChecksumAddress
 from web3 import Web3
@@ -146,3 +147,26 @@ class Catalog():
             raise Exception(f'No such token id({token_id}) on catalog({self.address})')
         assert len(tmp) == 1
         return tmp[0]
+
+    def register_cti(self, token: ChecksumAddress, uuid: UUID, title: str, price: int) -> None:
+        if price < 0:
+            raise Exception(f'Invalid price: {price}')
+        cti_catalog = CTICatalog(self.web3).get(self.address)
+        cti_catalog.register_cti(token, uuid, title, price, '')
+
+    def publish_cti(self, producer: ChecksumAddress, token: ChecksumAddress) -> None:
+        assert self.address
+        cti_catalog = CTICatalog(self.web3).get(self.address)
+        cti_catalog.publish_cti(producer, token)
+
+    def modify_cti(self, token: ChecksumAddress, uuid: UUID, title: str, price: int) -> None:
+        if price < 0:
+            raise Exception(f'Invalid price: {price}')
+        assert self.address
+        cti_catalog = CTICatalog(self.web3).get(self.address)
+        cti_catalog.modify_cti(token, uuid, title, price, '')
+
+    def unregister_cti(self, token: ChecksumAddress) -> None:
+        assert self.address
+        cti_catalog = CTICatalog(self.web3).get(self.address)
+        cti_catalog.unregister_cti(token)

--- a/metemcyber/core/bc/catalog.py
+++ b/metemcyber/core/bc/catalog.py
@@ -43,15 +43,6 @@ class CatalogInfo():
         self.private = None
         self.tokens: Dict[ChecksumAddress, TokenInfo] = {}
 
-    def tokeninfo_by_address(
-            self, address: ChecksumAddress) -> Optional[TokenInfo]:
-        return self.tokens.get(address)
-
-    def tokeninfo_by_id(self, token_id: int) -> Optional[TokenInfo]:
-        tmp = [info for info in self.tokens.values()
-               if info.token_id == token_id]
-        return tmp[0] if tmp else None
-
 
 class Catalog():
     __addressed_catalogs: Dict[ChecksumAddress, CatalogInfo] = {}

--- a/metemcyber/core/bc/catalog_manager.py
+++ b/metemcyber/core/bc/catalog_manager.py
@@ -24,8 +24,8 @@ from .catalog import Catalog
 
 class CatalogManager():
     def __init__(self, web3: Web3) -> None:
-        #                   catalog_address  catalog_id
         self.web3: Web3 = web3
+        #                   catalog_address  catalog_id
         self.catalogs: Dict[ChecksumAddress, int] = {}
         self.actives: Set[ChecksumAddress] = set()
 

--- a/metemcyber/core/bc/catalog_manager.py
+++ b/metemcyber/core/bc/catalog_manager.py
@@ -38,17 +38,21 @@ class CatalogManager():
 
     def remove(self, addresses: List[ChecksumAddress]) -> None:
         for address in addresses:
+            if address not in self.catalogs.keys():
+                raise Exception(f'No such catalog: {address}')
             del self.catalogs[address]
             self.actives.discard(address)
 
     def activate(self, addresses: List[ChecksumAddress]) -> None:
         for address in addresses:
-            assert address in self.catalogs.keys()
+            if address not in self.catalogs.keys():
+                raise Exception(f'No such catalog: {address}')
             self.actives.add(address)
 
     def deactivate(self, addresses: List[ChecksumAddress]) -> None:
         for address in addresses:
-            assert address in self.catalogs.keys()
+            if address not in self.catalogs.keys():
+                raise Exception(f'No such catalog: {address}')
             self.actives.discard(address)
 
     def _catalogs(self, active: Optional[bool]) -> Dict[ChecksumAddress, int]:

--- a/metemcyber/core/bc/contract.py
+++ b/metemcyber/core/bc/contract.py
@@ -58,11 +58,16 @@ class Contract():
     def __init__(self, web3: Web3):
         assert web3
         self.web3 = web3  # should be initialized with EOA & private key
-        self.contract = None  # initialized by get()
+        self._contract = None  # initialized by get()
+
+    @property
+    def contract(self):
+        assert self._contract
+        return self._contract
 
     @property
     def address(self):
-        return self.contract.address if self.contract else None
+        return self._contract.address if self._contract else None
 
     def new(self, *args, **kwargs):
         assert self.web3
@@ -77,7 +82,7 @@ class Contract():
             raise Exception('Invalid address: {}'.format(address))
         # pylint: disable=protected-access
         self.__class__.__load()
-        self.contract = self.web3.eth.contract(
+        self._contract = self.web3.eth.contract(
             address=address, abi=self.__class__.contract_interface['abi'])
         return self
 

--- a/metemcyber/core/bc/cti_catalog.py
+++ b/metemcyber/core/bc/cti_catalog.py
@@ -14,7 +14,10 @@
 #    limitations under the License.
 #
 
-from typing import Dict
+from typing import Dict, List, Tuple, cast
+from uuid import UUID
+
+from eth_typing import ChecksumAddress
 
 from .contract import Contract
 
@@ -27,7 +30,8 @@ class CTICatalog(Contract):
         func = self.contract.functions.getOwner()
         return func.call()
 
-    def publish_cti(self, producer_address, token_address):
+    def publish_cti(self, producer_address: ChecksumAddress,
+                    token_address: ChecksumAddress) -> None:
         self.log_trace()
         func = self.contract.functions.publishCti(
             producer_address, token_address)
@@ -38,10 +42,11 @@ class CTICatalog(Contract):
             raise ValueError('Transaction failed: publishCti')
         self.log_success()
 
-    def register_cti(self, token_address, uuid, title, price, operator):
+    def register_cti(self, token_address: ChecksumAddress, uuid: UUID, title: str, price: int,
+                     operator: str) -> None:
         self.log_trace()
         func = self.contract.functions.registerCti(
-            token_address, uuid, title, price, operator)
+            token_address, str(uuid), title, price, operator)
         tx_hash = func.transact()
         tx_receipt = self.web3.eth.waitForTransactionReceipt(tx_hash)
         self.gaslog('registerCti', tx_receipt)
@@ -49,10 +54,11 @@ class CTICatalog(Contract):
             raise ValueError('Transaction failed: registerCti')
         self.log_success()
 
-    def modify_cti(self, token_address, uuid, title, price, operator):
+    def modify_cti(self, token_address: ChecksumAddress, uuid: UUID, title: str, price: int,
+                   operator: str) -> None:
         self.log_trace()
         func = self.contract.functions.modifyCti(
-            token_address, uuid, title, price, operator)
+            token_address, str(uuid), title, price, operator)
         tx_hash = func.transact()
         tx_receipt = self.web3.eth.waitForTransactionReceipt(tx_hash)
         self.gaslog('modifyCti', tx_receipt)
@@ -60,7 +66,7 @@ class CTICatalog(Contract):
             raise ValueError('Transaction failed: modifyCti')
         self.log_success()
 
-    def unregister_cti(self, token_address):
+    def unregister_cti(self, token_address: ChecksumAddress):
         self.log_trace()
         func = self.contract.functions.unregisterCti(token_address)
         tx_hash = func.transact()
@@ -76,13 +82,14 @@ class CTICatalog(Contract):
         tokens = func.call()
         return [t for t in tokens if t != '']
 
-    def get_cti_info(self, token_address):
+    def get_cti_info(self, token_address: ChecksumAddress) -> Tuple[
+            int, ChecksumAddress, UUID, str, int, str, dict]:
         self.log_trace()
         func = self.contract.functions.getCtiInfo(token_address)
         token_id, owner, uuid, title, price, operator, likecount = func.call()
-        return token_id, owner, uuid, title, price, operator, likecount
+        return token_id, cast(ChecksumAddress, owner), UUID(uuid), title, price, operator, likecount
 
-    def like_cti(self, token_address):
+    def like_cti(self, token_address: ChecksumAddress) -> None:
         self.log_trace()
         func = self.contract.functions.likeCti(token_address)
         tx_hash = func.transact()
@@ -92,7 +99,7 @@ class CTICatalog(Contract):
             raise ValueError('Transaction failed: likeCti')
         self.log_success()
 
-    def get_like_event(self, search_blocks=1000):
+    def get_like_event(self, search_blocks: int = 1000) -> list:
         self.log_trace()
         # 最大search_blocks数だけ、CtiLiked eventを取得して返す
         from_block = max(
@@ -103,12 +110,12 @@ class CTICatalog(Contract):
         event_logs = event_filter.get_all_entries()
         return event_logs
 
-    def is_private(self):
+    def is_private(self) -> None:
         self.log_trace()
         func = self.contract.functions.isPrivate()
         return func.call()
 
-    def set_private(self):
+    def set_private(self) -> None:
         self.log_trace()
         func = self.contract.functions.setPrivate()
         tx_hash = func.transact()
@@ -118,7 +125,7 @@ class CTICatalog(Contract):
             raise ValueError('Transaction failed: setPrivate')
         self.log_success()
 
-    def set_public(self):
+    def set_public(self) -> None:
         self.log_trace()
         func = self.contract.functions.setPublic()
         tx_hash = func.transact()
@@ -128,7 +135,7 @@ class CTICatalog(Contract):
             raise ValueError('Transaction failed: setPublic')
         self.log_success()
 
-    def authorize_user(self, eoa_address):
+    def authorize_user(self, eoa_address: ChecksumAddress) -> None:
         self.log_trace()
         func = self.contract.functions.authorizeUser(eoa_address)
         tx_hash = func.transact()
@@ -138,7 +145,7 @@ class CTICatalog(Contract):
             raise ValueError('Transaction failed: authorizeUser')
         self.log_success()
 
-    def revoke_user(self, eoa_address):
+    def revoke_user(self, eoa_address: ChecksumAddress) -> None:
         self.log_trace()
         func = self.contract.functions.revokeUser(eoa_address)
         tx_hash = func.transact()
@@ -148,7 +155,7 @@ class CTICatalog(Contract):
             raise ValueError('Transaction failed: revokeUser')
         self.log_success()
 
-    def show_authorized_users(self):
+    def show_authorized_users(self) -> List[ChecksumAddress]:
         self.log_trace()
         func = self.contract.functions.showAuthorizedUsers()
         return func.call()

--- a/metemcyber/core/bc/operator.py
+++ b/metemcyber/core/bc/operator.py
@@ -1,0 +1,37 @@
+#
+#    Copyright 2021, NTT Communications Corp.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+from typing import Optional
+
+from eth_typing import ChecksumAddress
+from web3 import Web3
+
+from .cti_operator import CTIOperator
+
+
+class Operator():
+    def __init__(self, web3: Web3) -> None:
+        self.web3: Web3 = web3
+        self.address: Optional[ChecksumAddress] = None
+
+    def get(self, address: ChecksumAddress) -> 'Operator':
+        self.address = address
+        return self
+
+    def new(self) -> 'Operator':
+        assert self.web3
+        cti_operator = CTIOperator(self.web3).new()
+        return self.get(cti_operator.address)


### PR DESCRIPTION
トークン生成・カタログ登録・ブローカー委託までのコマンドを移植しました。
1. ix token create "Initial Supply"  でトークン生成。表示されるトークンアドレスは自己管理。
2. catalog register "Catalog Address" "Token Address" "UUID" "Title" "Price" でカタログ登録。
3. catalog publish "Catalog Address" "Token Address"  で公開。（この時点でトークンIDが付与される）
4. ix list  のリストに出てくる。（この時点ではブローカーに委託してないので --soldout オプションが必要）
5. ix consign "Token Index" "Amount"  でブローカーに委託。
6. ix buy "Token Index" で購入可能。

catalog コマンドは --by-id でカタログID指定も可能。
"Token Index" は "CatalogID - TokenID" の文字列（ix list で出てくるやつ）です。
ix list に５種のオプションを追加してあります。目的に応じて使い分けてください。
catalog register する際の UUID（とTitle）がトークンの実データの関連付けになりますが、どういったユーザー補助が適当かは今後の検討課題です。