### PR TITLE
Topic/add ix seeker,solver

### DIFF
--- a/metemcyber/cli/cli.py
+++ b/metemcyber/cli/cli.py
@@ -40,6 +40,7 @@ from metemcyber.core.bc.metemcyber_util import MetemcyberUtil
 from metemcyber.core.bc.operator import TASK_STATES, Operator
 from metemcyber.core.bc.token import Token
 from metemcyber.core.logger import get_logger
+from metemcyber.core.seeker import Seeker
 
 APP_NAME = "metemcyber"
 APP_DIR = typer.get_app_dir(APP_NAME)
@@ -66,6 +67,8 @@ ix_operator_app = typer.Typer()
 ix_app.add_typer(ix_operator_app, name='operator', help="Manage the CTI operator contract.")
 ix_challenge_app = typer.Typer()
 ix_app.add_typer(ix_challenge_app, name='challenge', help="Execute tasks using the CTI token.")
+ix_seeker_app = typer.Typer()
+ix_app.add_typer(ix_seeker_app, name='seeker', help='Manage CTI seeker subprocess.')
 
 catalog_app = typer.Typer()
 app.add_typer(catalog_app, name="catalog", help="Manage the CTI catalog contract.")
@@ -538,6 +541,46 @@ def ix_token_create(ctx: typer.Context, initial_supply: int):
             raise Exception(f'Invalid initial-supply: {initial_supply}')
         token = Token(account).new(initial_supply, [])
         typer.echo(f'created a new token. address is {token.address}.')
+    except Exception as err:
+        logger.exception(err)
+        typer.echo(f'failed operation: {err}')
+
+
+@ix_seeker_app.command('status')
+def ix_seeker_status(_ctx: typer.Context):
+    logger = getLogger()
+    try:
+        seeker = Seeker()
+        if seeker.pid == 0:
+            typer.echo(f'not running.')
+        else:
+            typer.echo(f'running on pid {seeker.pid}, listening {seeker.address}:{seeker.port}.')
+    except Exception as err:
+        logger.exception(err)
+        typer.echo(f'failed operation: {err}')
+
+
+@ix_seeker_app.command('start')
+def ix_seeker_start(_ctx: typer.Context,
+                    local: bool = typer.Option(True, help='listen localhost only')):
+    logger = getLogger()
+    try:
+        seeker = Seeker(local)
+        seeker.start()
+        typer.echo(f'seeker started on process {seeker.pid}, '
+                   f'listening {seeker.address}:{seeker.port}.')
+    except Exception as err:
+        logger.exception(err)
+        typer.echo(f'failed operation: {err}')
+
+
+@ix_seeker_app.command('stop')
+def ix_seeker_stop(_ctx: typer.Context):
+    logger = getLogger()
+    try:
+        seeker = Seeker()
+        seeker.stop()
+        typer.echo(f'seeker stopped.')
     except Exception as err:
         logger.exception(err)
         typer.echo(f'failed operation: {err}')

--- a/metemcyber/cli/cli.py
+++ b/metemcyber/cli/cli.py
@@ -670,7 +670,7 @@ def ix_solver_apply(ctx: typer.Context,
         solver = _solver_client(ctx)
         applied = solver.new_solver(operator.address, pluginfile=plugin)
         assert applied == operator.address
-        typer.echo(f'Solver is now running with your operator({new}).')
+        typer.echo(f'Solver is now running with your operator({applied}).')
     except Exception as err:
         logger.exception(err)
         typer.echo(f'failed operation: {err}')

--- a/metemcyber/core/bc/account.py
+++ b/metemcyber/core/bc/account.py
@@ -14,11 +14,19 @@
 #    limitations under the License.
 #
 
+from typing import Callable
+
+from eth_typing import ChecksumAddress
+from web3 import Web3
+
+from .ether import Ether
+from .util import sign_message
 from .wallet import Wallet
 
 
 class Account:
-    def __init__(self, web3, eoa):
-        self.eoa = eoa
-        self.web3 = web3
-        self.wallet = Wallet(web3, eoa)
+    def __init__(self, ether: Ether, eoa: str, pkey: str) -> None:
+        self.eoa: ChecksumAddress = Web3.toChecksumAddress(eoa)
+        self.web3: Web3 = ether.web3_with_signature(pkey)
+        self.wallet: Wallet = Wallet(self.web3, eoa)
+        self.sign_message: Callable[[str], str] = lambda x: sign_message(x, pkey)

--- a/metemcyber/core/bc/catalog_manager.py
+++ b/metemcyber/core/bc/catalog_manager.py
@@ -17,21 +17,21 @@
 from typing import Dict, List, Optional, Set
 
 from eth_typing import ChecksumAddress
-from web3 import Web3
 
+from .account import Account
 from .catalog import Catalog
 
 
 class CatalogManager():
-    def __init__(self, web3: Web3) -> None:
-        self.web3: Web3 = web3
+    def __init__(self, account: Account) -> None:
+        self.account: Account = account
         #                   catalog_address  catalog_id
         self.catalogs: Dict[ChecksumAddress, int] = {}
         self.actives: Set[ChecksumAddress] = set()
 
     def add(self, addresses: List[ChecksumAddress], activate=False) -> None:
         for address in addresses:
-            catalog = Catalog(self.web3).get(address)
+            catalog = Catalog(self.account).get(address)
             self.catalogs[address] = catalog.catalog_id
             if activate:
                 self.actives.add(address)

--- a/metemcyber/core/bc/eventlistener.py
+++ b/metemcyber/core/bc/eventlistener.py
@@ -1,0 +1,151 @@
+#
+#    Copyright 2021, NTT Communications Corp.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+import time
+from threading import Lock, Thread
+from typing import Any, Callable, Dict, List, Optional
+
+from requests.exceptions import ConnectionError as ConnError
+from requests.exceptions import HTTPError
+from web3._utils.filters import LogFilter
+from web3.datastructures import AttributeDict
+
+from ..logger import get_logger
+
+LOGGER = get_logger(name='event', file_prefix='core.bc')
+
+EVENT_POLLING_INTERVAL_SEC = 2
+LISTENER_JOIN_TIMEOUT_SEC = 30
+
+
+class BasicEventListener:
+
+    def __init__(self, identity: str) -> None:
+        self.__thread: Optional[Thread] = None
+        self.__identity: str = identity
+        self.__stopping: bool = True
+        self.__prefix: str = self.__class__.__name__
+        #                          key: {filter:x, count:x, callback:x}
+        self.__event_filters: Dict[str, Dict[str, Any]] = {}
+        self.__lock: Lock = Lock()
+        #                           {key:x, filter:x, callback:x}
+        self.__pending_filters: List[Dict[str, Any]] = list()
+        self.__pending_lock: Lock = Lock()
+
+    def destroy(self) -> None:
+        self.stop()
+
+    def add_event_filter(self, key: str, event_filter: LogFilter,
+                         callback: Callable[[AttributeDict[Any, Any]], None]) -> None:
+        self.__lock.acquire()
+        if key in self.__event_filters.keys():
+            assert self.__event_filters[key]['callback'] == callback
+            self.__event_filters[key]['count'] += 1
+        else:
+            self.__event_filters[key] = {
+                'filter': event_filter, 'callback': callback, 'count': 1}
+            LOGGER.debug('start watching: %s', key)
+        self.__lock.release()
+        if not self.__stopping:
+            self.start()
+
+    def remove_event_filter(self, key: str) -> None:
+        self.__lock.acquire()
+        self.__event_filters[key]['count'] -= 1
+        if self.__event_filters[key]['count'] <= 0:
+            del self.__event_filters[key]
+            LOGGER.debug('remove watching: %s', key)
+        self.__lock.release()
+        # auto-stopped in __run() if __event_filters is empty.
+
+    def add_event_filter_in_callback(self, key: str, event_filter: LogFilter,
+                                     callback: Callable[[AttributeDict[Any, Any]], None]) -> None:
+        self.__pending_lock.acquire()
+        self.__pending_filters.append(
+            {'key': key, 'filter': event_filter, 'callback': callback})
+        self.__pending_lock.release()
+
+    def remove_event_filter_in_callback(self, key: str) -> None:
+        self.__pending_lock.acquire()
+        self.__pending_filters.append({'key': key, 'filter': None})
+        self.__pending_lock.release()
+
+    def start(self) -> None:
+        if self.__thread:
+            return
+        self.__stopping = False
+        if len(self.__event_filters) == 0:
+            return
+        self.__thread = Thread(target=self.__run, daemon=True)
+        self.__thread.start()
+
+    def stop(self) -> None:
+        if not self.__thread:
+            return
+        LOGGER.info('%s: stopping %s', self.__prefix, self.__identity)
+        self.__stopping = True
+        self.__thread.join(timeout=LISTENER_JOIN_TIMEOUT_SEC)
+        if self.__thread and self.__thread.is_alive():
+            LOGGER.error('failed stopping listener: %s', self.__identity)
+            return
+        self.__event_filters.clear()
+        self.__pending_filters.clear()
+        self.__thread = None
+
+    def __run(self) -> None:
+        LOGGER.info('%s: starting %s', self.__prefix, self.__identity)
+        while True:
+            if len(self.__event_filters) == 0:
+                break
+
+            self.__lock.acquire()
+            for value in self.__event_filters.values():
+                try:
+                    events = value['filter'].get_new_entries()
+                except (ConnError, HTTPError) as err:
+                    LOGGER.warning(
+                        'could not connect to ethereum network: %s', err)
+                    break  # retry on next time
+
+                for event in events:
+                    if self.__stopping:
+                        break
+                    LOGGER.info(
+                        'event %s: address=%s args=%s',
+                        event['event'], event['address'], event['args'])
+
+                    Thread(target=value['callback'], args=[event]).start()
+
+                if self.__stopping:
+                    break
+            self.__lock.release()
+
+            if self.__stopping:
+                break
+            time.sleep(EVENT_POLLING_INTERVAL_SEC)
+
+            self.__pending_lock.acquire()
+            for item in self.__pending_filters:
+                if item['filter']:
+                    self.add_event_filter(
+                        item['key'], item['filter'], item['callback'])
+                else:
+                    self.remove_event_filter(item['key'])
+            self.__pending_filters.clear()
+            self.__pending_lock.release()
+
+        LOGGER.info('%s: thread exiting: %s', self.__prefix, self.__identity)
+        self.__thread = None

--- a/metemcyber/core/bc/operator.py
+++ b/metemcyber/core/bc/operator.py
@@ -17,16 +17,16 @@
 from typing import List, Optional, Tuple
 
 from eth_typing import ChecksumAddress
-from web3 import Web3
 
+from .account import Account
 from .cti_operator import CTIOperator
 
 TASK_STATES = ['Pending', 'Accepted', 'Finished', 'Cancelled']
 
 
 class Operator():
-    def __init__(self, web3: Web3) -> None:
-        self.web3: Web3 = web3
+    def __init__(self, account: Account) -> None:
+        self.account: Account = account
         self.address: Optional[ChecksumAddress] = None
 
     def get(self, address: ChecksumAddress) -> 'Operator':
@@ -34,17 +34,14 @@ class Operator():
         return self
 
     def new(self) -> 'Operator':
-        assert self.web3
-        cti_operator = CTIOperator(self.web3).new()
+        cti_operator = CTIOperator(self.account).new()
         return self.get(cti_operator.address)
 
     def history(self, token: ChecksumAddress, limit: int, offset: int
                 ) -> List[Tuple[int, ChecksumAddress, ChecksumAddress, ChecksumAddress, int]]:
-        assert self.web3
         assert self.address
-        return CTIOperator(self.web3).get(self.address).history(token, limit, offset)
+        return CTIOperator(self.account).get(self.address).history(token, limit, offset)
 
     def cancel_challenge(self, task_id: int) -> None:
-        assert self.web3
         assert self.address
-        CTIOperator(self.web3).get(self.address).cancel_challenge(task_id)
+        CTIOperator(self.account).get(self.address).cancel_challenge(task_id)

--- a/metemcyber/core/bc/token.py
+++ b/metemcyber/core/bc/token.py
@@ -17,8 +17,8 @@
 from typing import Dict, List, Optional
 
 from eth_typing import ChecksumAddress
-from web3 import Web3
 
+from .account import Account
 from .cti_token import CTIToken
 
 
@@ -26,8 +26,8 @@ class Token():
     #                token address         eoa address      balance
     tokens_map: Dict[ChecksumAddress, Dict[ChecksumAddress, int]] = {}
 
-    def __init__(self, web3: Web3) -> None:
-        self.web3: Web3 = web3
+    def __init__(self, account: Account) -> None:
+        self.account: Account = account
         self.address: Optional[ChecksumAddress] = None
 
     def get(self, address: ChecksumAddress) -> 'Token':
@@ -36,8 +36,7 @@ class Token():
 
     def new(self, initial_supply: int,
             default_operators: List[ChecksumAddress]) -> 'Token':
-        assert self.web3
-        cti_token = CTIToken(self.web3).new(initial_supply, default_operators)
+        cti_token = CTIToken(self.account).new(initial_supply, default_operators)
         return self.get(cti_token.address)
 
     def uncache(self, entire: bool = False) -> None:
@@ -54,21 +53,19 @@ class Token():
         if self.address not in Token.tokens_map.keys():
             Token.tokens_map[self.address] = {}
         if target not in Token.tokens_map[self.address].keys():
-            cti_token = CTIToken(self.web3).get(self.address)
+            cti_token = CTIToken(self.account).get(self.address)
             balance = cti_token.balance_of(target)
             Token.tokens_map[self.address][target] = balance
         return Token.tokens_map[self.address][target]
 
     def send(self, dest: ChecksumAddress, amount: int, data: str = '') -> None:
-        assert self.web3
         assert self.address
-        cti_token = CTIToken(self.web3).get(self.address)
+        cti_token = CTIToken(self.account).get(self.address)
         cti_token.send_token(dest, amount, data)
         self.uncache()
 
     def burn(self, amount: int, data: str = '') -> None:
-        assert self.web3
         assert self.address
-        cti_token = CTIToken(self.web3).get(self.address)
+        cti_token = CTIToken(self.account).get(self.address)
         cti_token.burn_token(amount, data)
         self.uncache()

--- a/metemcyber/core/bc/util.py
+++ b/metemcyber/core/bc/util.py
@@ -16,7 +16,7 @@
 
 import json
 from getpass import getpass
-from typing import Tuple, cast
+from typing import Callable, Tuple, cast
 
 from eth_account.messages import encode_defunct
 from eth_typing import ChecksumAddress
@@ -40,11 +40,13 @@ def verify_message(message: str, signature: str) -> ChecksumAddress:
     return signer
 
 
-def decode_keyfile(filename: str) -> Tuple[ChecksumAddress, str]:
+def decode_keyfile(filename: str,
+                   password_func: Callable[[], str] = lambda: getpass('Enter password for keyfile:')
+                   ) -> Tuple[ChecksumAddress, str]:
     # https://web3py.readthedocs.io/en/stable/web3.eth.account.html#extract-private-key-from-geth-keyfile
     with open(filename) as keyfile:
         enc_data = keyfile.read()
     address = Web3.toChecksumAddress(json.loads(enc_data)['address'])
-    word = getpass('Enter password for keyfile:')
+    word = password_func()
     private_key = w3.eth.account.decrypt(enc_data, word).hex()
     return Web3.toChecksumAddress(address), private_key

--- a/metemcyber/core/bc/util.py
+++ b/metemcyber/core/bc/util.py
@@ -1,0 +1,50 @@
+#
+#    Copyright 2021, NTT Communications Corp.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+import json
+from getpass import getpass
+from typing import Tuple, cast
+
+from eth_account.messages import encode_defunct
+from eth_typing import ChecksumAddress
+from hexbytes import HexBytes
+from web3 import Web3
+from web3.auto import w3
+
+ADDRESS0 = cast(ChecksumAddress, '0x{:040x}'.format(0))
+
+
+def sign_message(message: str, private_key: str) -> str:
+    enc_msg = encode_defunct(text=message)
+    signed_msg = w3.eth.account.sign_message(enc_msg, private_key=private_key)
+    signature = signed_msg.signature.hex()
+    return signature
+
+
+def verify_message(message: str, signature: str) -> ChecksumAddress:
+    enc_msg = encode_defunct(text=message)
+    signer = w3.eth.account.recover_message(enc_msg, signature=HexBytes(signature))
+    return signer
+
+
+def decode_keyfile(filename: str) -> Tuple[ChecksumAddress, str]:
+    # https://web3py.readthedocs.io/en/stable/web3.eth.account.html#extract-private-key-from-geth-keyfile
+    with open(filename) as keyfile:
+        enc_data = keyfile.read()
+    address = Web3.toChecksumAddress(json.loads(enc_data)['address'])
+    word = getpass('Enter password for keyfile:')
+    private_key = w3.eth.account.decrypt(enc_data, word).hex()
+    return Web3.toChecksumAddress(address), private_key

--- a/metemcyber/core/multi_solver.py
+++ b/metemcyber/core/multi_solver.py
@@ -1,0 +1,662 @@
+#
+#    Copyright 2021, NTT Communications Corp.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+import inspect
+import json
+import os
+import select
+import signal
+import socket
+import sys
+from enum import IntEnum, auto
+from threading import Condition, Thread
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union, cast
+
+from cryptography.fernet import Fernet
+from eth_typing import ChecksumAddress
+from web3 import Web3
+
+from metemcyber.core.bc.account import Account
+from metemcyber.core.bc.cti_operator import CTIOperator
+from metemcyber.core.bc.ether import Ether
+from metemcyber.core.bc.util import sign_message, verify_message
+from metemcyber.core.logger import get_logger
+from metemcyber.core.plugin import PluginManager
+from metemcyber.core.solver import BaseSolver
+
+SERVERLOG = get_logger(name='solv_server', file_prefix='core')
+CLIENTLOG = get_logger(name='solv_client', file_prefix='core')
+
+SOCKET_FILE = './mcs.sock'  # FIXME
+NUM_THREADS = 4
+BUFSIZ = 4096
+
+ARGS_DELIMITER = '\t'   # for command line input
+EOM = '\v'  # End of Message
+
+
+def tracelog(logger, *args, **kwargs):
+    stacks = inspect.stack()
+    assert len(stacks) > 1
+    finfo = inspect.getframeinfo(stacks[1][0])
+    pref = '{}:{} {}'.format(
+        os.path.basename(finfo.filename),
+        finfo.lineno, finfo.function)
+    if len(args) > 0:
+        logger.debug(pref + ': ' + args[0], *args[1:], **kwargs)
+    else:
+        logger.debug(pref, **kwargs)
+
+
+class DataPack:
+    def __init__(self, code, eoaa, *args, **kwargs):
+        self.code: Union[str, int] = code  # MCSErrno or function
+        self.eoaa: Optional[ChecksumAddress] = eoaa
+        self.args: Tuple[Any, ...] = args
+        self.kwargs: Dict[str, Any] = kwargs
+        self.sign: Optional[str] = None
+
+    @classmethod
+    def from_string(cls, str_data: str) -> 'DataPack':
+        jdata = json.loads(str_data)
+        inst = cls(
+            jdata.get('code'),
+            jdata.get('eoaa'),
+            *jdata.get('args', []),
+            **jdata.get('kwargs', {}))
+        inst.sign = jdata.get('sign')
+        return inst
+
+    def __str__(self):  # sign is not included
+        return json.dumps({
+            'code': self.code,
+            'eoaa': self.eoaa,
+            'args': self.args,
+            'kwargs': self.kwargs,
+        })
+
+    @property
+    def signed_string(self):  # include sign
+        return json.dumps({
+            'code': self.code,
+            'eoaa': self.eoaa,
+            'args': self.args,
+            'kwargs': self.kwargs,
+            'sign': self.sign,
+        })
+
+    def sign_message(self, pkey) -> 'DataPack':
+        if pkey:
+            self.sign = sign_message(str(self), pkey)
+        return self  # for DataPack(...).sign_message(pkey).send(conn)
+
+    def verify(self) -> bool:
+        if self.eoaa and self.sign:
+            return verify_message(str(self), self.sign) == self.eoaa
+        return False
+
+    def send(self, sock):
+        msg = (self.signed_string + EOM).encode()
+        total = 0
+        while total < len(msg):
+            tmp = sock.send(msg[total:], socket.SOCK_NONBLOCK)
+            if tmp == 0:
+                raise Exception('Disconnected by peer')
+            total += tmp
+
+
+class MCSErrno(IntEnum):
+    OK = 0xE000
+    EPROTO = auto()
+    EINVAL = auto()
+    ENOP = auto()
+    EALREADY = auto()
+    ENOENT = auto()
+    EINTERNAL = auto()
+    EUNKNOWN = auto()
+
+
+class MCSError(Exception):
+    def __init__(self, code: MCSErrno, msg: Optional[str] = None):
+        super().__init__(self)
+        self.code = code
+        self.msg = msg if msg else {
+            MCSErrno.OK: 'OK',
+            MCSErrno.EPROTO: 'Protocol Error',
+            MCSErrno.EINVAL: 'Invalid Parameter',
+            MCSErrno.ENOP: 'Nothing to Operate',
+            MCSErrno.EALREADY: 'Already Exists',
+            MCSErrno.ENOENT: 'No Such Entry',
+        }.get(code, 'Unknown Error')
+
+    def __str__(self):
+        return '{:04X}: {:s}'.format(self.code, self.msg)
+
+
+class SolverManager():
+    """ Class to manage Solver instances
+    """
+
+    def __init__(self, endpoint_url: str, _eoaa: Optional[ChecksumAddress], _pkey: str,
+                 _operator_address: Optional[ChecksumAddress], _pluginfile: Optional[str]
+                 ) -> None:
+        self.endpoint_url = endpoint_url
+        self.plugin = PluginManager()
+        self.plugin.load()
+        self.plugin.set_default_solverclass('gcs_solver.py')
+        self.fernet_key: Optional[bytes] = None
+        #                  eoaa:            {account: x, solver: x}
+        self.solvers: Dict[ChecksumAddress, Dict[str, Any]] = {}
+
+        # FIXME: activate by commandline option. (pkey is not encrypted)
+        # if eoaa and pkey and operator_address:
+        #     self.new_solver(eoaa, pkey, operator_address, pluginfile)
+
+    def destroy(self):
+        for solver in [v['solver'] for v in self.solvers.values()]:
+            solver.destroy()
+
+    def new_solver(self, eoaa: ChecksumAddress,
+                   encrypted_pkey: str,
+                   operator_address: Optional[ChecksumAddress],
+                   solver_plugin: Optional[str] = None
+                   ) -> BaseSolver:
+        cache = self.solvers.get(eoaa)
+        if not cache or not cache['fernet_key']:
+            raise MCSError(MCSErrno.EPROTO, 'Protocol error1')
+        if cache['solver']:
+            raise MCSError(MCSErrno.EALREADY, 'Already exists for this EOA')
+        if not encrypted_pkey:
+            raise MCSError(MCSErrno.EINVAL, 'Missing privatekey')
+        if solver_plugin and not self.plugin.is_pluginfile(solver_plugin):
+            raise MCSError(MCSErrno.EINVAL, 'Invalid pluginfile')
+
+        fnt = Fernet(cache['fernet_key'])
+        pkey: str = fnt.decrypt(encrypted_pkey.encode('utf-8')).decode()
+        cache['fernet_key'] = None
+        account = Account(Ether(self.endpoint_url), eoaa, pkey)
+
+        if not operator_address:  # deploy a new contract
+            cti_operator = CTIOperator(account).new()
+            operator_address = cti_operator.address
+            cti_operator.set_recipient()
+        assert operator_address
+        if solver_plugin:
+            self.plugin.set_solverclass(operator_address, solver_plugin)
+        solverclass = self.plugin.get_solverclass(operator_address)
+        solver = solverclass(account, operator_address)
+
+        cache['solver'] = solver
+        cache['account'] = account
+
+        tracelog(SERVERLOG, 'added solver: %s', cache)
+        return cache['solver']
+
+    def get_fernet_key(self, dpk: DataPack) -> DataPack:
+        assert dpk.eoaa
+        cache = self.solvers.get(dpk.eoaa)
+        if not cache:
+            cache = {
+                'account': None,
+                'solver': None,
+                'fernet_key': Fernet.generate_key(),
+            }
+            self.solvers[dpk.eoaa] = cache
+        if not cache['fernet_key']:
+            cache['fernet_key'] = Fernet.generate_key()
+        return DataPack(MCSErrno.OK, None, data=cache['fernet_key'].decode())
+
+    def _solver_control(self, eoaa: ChecksumAddress, act: str) -> Optional[BaseSolver]:
+        cache = self.solvers.get(eoaa)
+        if not cache:
+            raise MCSError(MCSErrno.ENOENT, 'Not found')
+        if not Web3.isChecksumAddress(eoaa):
+            raise MCSError(MCSErrno.EINVAL, 'Not a checksum address')
+
+        if act == 'get':
+            return cache['solver']
+
+        # act == 'purge'
+        tracelog(SERVERLOG, 'purge solver: %s', str(cache['solver']))
+        self.solvers[eoaa]['solver'].destroy()
+        del self.solvers[eoaa]
+        return None
+
+    def get_solver(self, eoaa):
+        return self._solver_control(eoaa, act='get')
+
+    def purge_solver(self, eoaa):
+        return self._solver_control(eoaa, act='purge')
+
+
+class SolverThread():
+    """ Class to deal with one connection
+    """
+
+    def __init__(self, pool, index, mgr):
+        self.mgr = mgr
+        self.pool = pool
+        self.index = index
+        self.shutdown = False
+        self.conn = self.addr = None
+        self.solver = None
+        self.eoaa: Optional[ChecksumAddress] = None
+        self.cond = Condition()
+        self.thread = Thread(target=self.run, daemon=False)
+        self.thread.start()
+        tracelog(SERVERLOG, '%d: initialized thread', index)
+
+    def destroy(self):
+        self.stop()
+
+    def stop(self):
+        if not self.thread:
+            return
+        tracelog(SERVERLOG, '%d: stopping thread', self.index)
+        self.shutdown = True
+        if self.cond and self.cond.acquire(timeout=1):
+            # got lock. thread may be waiting with cond.acquire().
+            self.cond.notify_all()
+            self.cond.release()
+        if self.thread:
+            tracelog(SERVERLOG, '%d: joinning thread', self.index)
+            self.thread.join()
+        self.thread = None
+        tracelog(SERVERLOG, '%d: thread stopped', self.index)
+
+    def apply_client(self, conn, addr):
+        assert self.conn is None
+        self.cond.acquire()
+        self.conn = conn
+        self.addr = addr
+        self.solver = None
+        self.eoaa = None
+        self.cond.notify()
+        tracelog(SERVERLOG, '%d: cond notify', self.index)
+        self.cond.release()
+
+    def _get_callback(self, func) -> Callable[[DataPack], DataPack]:
+        if func == 'ping':
+            return lambda *args, **kwargs: DataPack(MCSErrno.OK, None, data='pong')
+        if func == 'login':
+            return self._login
+
+        # following functions need login(eoaa).
+        if not self.eoaa:
+            raise MCSError(MCSErrno.EPROTO, 'Protocol error2')
+        if func in ('new_solver', 'get_solver', 'purge_solver'):
+            return self._solver_mgr_wrapper
+        if func == 'get_fernet_key':
+            return self.mgr.get_fernet_key
+        if func == 'solver':
+            return self._solver_wrapper
+
+        raise MCSError(MCSErrno.EINVAL, 'No such method')
+
+    def _login(self, dpk: DataPack) -> DataPack:
+        if self.eoaa:
+            raise MCSError(MCSErrno.EPROTO, 'Protocol error3')
+        if not Web3.isChecksumAddress(dpk.eoaa):
+            raise MCSError(MCSErrno.EINVAL, 'Not a ChecksumAddress')
+        self.eoaa = dpk.eoaa
+        return DataPack(MCSErrno.OK, None)
+
+    def _solver_mgr_wrapper(self, dpk: DataPack) -> DataPack:
+        assert dpk.code in ('new_solver', 'get_solver', 'purge_solver')
+        if (self.solver is None) == (dpk.code == 'purge_solver'):
+            raise MCSError(MCSErrno.EPROTO, 'Protocol error4')
+        self.solver = getattr(self.mgr, cast(str, dpk.code))(self.eoaa, *dpk.args, **dpk.kwargs)
+        if self.solver is None:
+            return DataPack(MCSErrno.OK, None)
+        return DataPack(MCSErrno.OK, None,
+                        operator_address=self.solver.operator_address,
+                        solver_class=str(self.solver))
+
+    def _solver_wrapper(self, dpk: DataPack) -> DataPack:
+        if not self.solver:
+            raise MCSError(MCSErrno.EPROTO, 'Protocol error5')
+        if len(dpk.args) < 1:
+            raise MCSError(MCSErrno.EINVAL, 'Missing function')
+        func = getattr(self.solver, dpk.args[0])
+        return DataPack(MCSErrno.OK, None, data=func(*dpk.args[1:], **dpk.kwargs))
+
+    def _treat_one_query(self, query: str, conn) -> Tuple[bool, bool]:  # (break, disconnect)
+        try:
+            dpk = DataPack.from_string(query)
+            if dpk.code != 'ping':  # need sign except ping
+                if not dpk.verify():
+                    raise MCSError(MCSErrno.EINVAL, 'Verify signature failed')
+                if self.eoaa and self.eoaa != dpk.eoaa:
+                    raise MCSError(MCSErrno.EINVAL, 'EOA address mismatch')
+            if dpk.code == 'shutdown':
+                signal.raise_signal(signal.SIGINT)
+                return True, False
+            if dpk.code == 'disconnect':
+                return True, True
+
+            resp = self._get_callback(dpk.code)(dpk)
+
+        except MCSError as err:
+            resp = DataPack(err.code, None, data=err.msg)
+        except Exception as err:
+            SERVERLOG.exception(err)
+            resp = DataPack(MCSErrno.EINTERNAL, None, data=str(err))
+
+        tracelog(SERVERLOG, 'retval: %X, %s, %s', resp.code, resp.args, resp.kwargs)
+        try:
+            resp.send(conn)
+        except Exception as err:
+            tracelog(SERVERLOG, '%d: send error: %s', self.index, err)
+        return False, False
+
+    def communicate(self, conn, _addr):
+        tracelog(SERVERLOG, '%d: communicate with %s', self.index, conn)
+        disconnect = False
+        msg = ''
+        while not disconnect:
+            while True:
+                rfds, _, _ = select.select([conn], [], [], 1.0)
+                if rfds or self.shutdown:
+                    break
+            if self.shutdown:
+                disconnect = True
+                tracelog(SERVERLOG, '%d: self.shutdown', self.index)
+                try:
+                    DataPack('SHUTDOWN', None).send(conn)
+                except Exception as err:
+                    tracelog(SERVERLOG, '%d: send error: %s', self.index, err)
+                break
+            tmp = conn.recv(BUFSIZ).decode()
+            if len(tmp) == 0:  # disconnected
+                tracelog(SERVERLOG, '%d: len == 0 (disconnect)', self.index)
+                break
+            msg += tmp
+            tracelog(SERVERLOG, 'received: ' + tmp.strip())
+            queries = msg.split(EOM)
+            tracelog(SERVERLOG, 'current queries: ' + str(queries))
+            for query in queries[:-1]:
+
+                brk, discon = self._treat_one_query(query, conn)
+
+                disconnect |= discon
+                if brk:
+                    break
+            msg = queries[-1]  # empty or incomplete msg
+        tracelog(SERVERLOG, '%d: disconnecting', self.index)
+        tracelog(SERVERLOG, '%d: closing %s', self.index, conn)
+        conn.close()
+
+    def run(self):
+        tracelog(SERVERLOG, '%d: start thread', self.index)
+        self.cond.acquire()
+        while True:
+            tracelog(SERVERLOG, '%d: cond waiting', self.index)
+            self.cond.wait()
+            tracelog(SERVERLOG, '%d: cond awaken', self.index)
+            if self.shutdown:
+                break
+            assert self.conn
+
+            self.communicate(self.conn, self.addr)
+
+            self.conn = self.addr = None
+            if self.shutdown:
+                break
+            self.pool.append(self)
+            tracelog(SERVERLOG, '%d: released', self.index)
+        tracelog(SERVERLOG, '%d: shuttting down', self.index)
+
+
+class MCSServer():
+    """ Class as a service
+    """
+
+    def __init__(self, mgr: SolverManager):
+        self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self.mgr = mgr
+        self.threadlist: List[SolverThread] = []  # all threads
+        self.threadpool: List[SolverThread] = []  # non-active threads
+        self.shutdown = False
+        signal.signal(signal.SIGINT, self.signal_handler)
+        for idx in range(NUM_THREADS):
+            sol_thr = SolverThread(self.threadpool, idx, mgr)
+            self.threadlist.append(sol_thr)
+            self.threadpool.append(sol_thr)
+
+    def signal_handler(self, signum, __):
+        if signum not in {signal.SIGINT}:
+            SERVERLOG.warning('caught un-expected signal: %d', signum)
+            return
+        tracelog(SERVERLOG, 'caught SIGINT')
+        self.shutdown = True
+        self.threadpool.clear()  # accept no more
+
+    def run(self):
+        try:
+            self.sock.bind(SOCKET_FILE)
+            self.sock.listen()
+            self.sock.settimeout(1)
+            while True:
+                try:
+                    conn, addr = self.sock.accept()
+                except socket.timeout:
+                    if self.shutdown:
+                        break
+                    continue
+                if len(self.threadpool) == 0:
+                    tracelog(SERVERLOG, 'too many connections')
+                    conn.close()
+                    continue
+                tracelog(SERVERLOG, 'accepted')
+                sol_thr = self.threadpool.pop()
+                sol_thr.apply_client(conn, addr)
+        finally:
+            for sol_thr in self.threadlist:
+                sol_thr.destroy()
+            if self.mgr:
+                self.mgr.destroy()
+            os.remove(SOCKET_FILE)
+        tracelog(SERVERLOG, 'MCSServer shutted down')
+
+
+class MCSClient():
+    """ Class as a client
+    """
+
+    def __init__(self, eoaa, pkey):
+        self.eoaa = eoaa
+        self.sign_message = lambda x: sign_message(x, pkey)
+        self.pkey = pkey  # XXX
+        self.sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self.operator_address = None
+        self.solver_class = None
+        self.disconnecting = False
+        self.buffer = ''
+        tracelog(CLIENTLOG, 'initialized %s', self)
+
+    def destroy(self):
+        self.disconnect()
+
+    def connect(self):
+        try:
+            self.sock.connect(SOCKET_FILE)
+        except FileNotFoundError as err:
+            raise Exception('Socket not found. Solver daemon may be down.') \
+                from err
+        except OSError as err:
+            if err.errno != 106:  # ignore EISCONN (already connected)
+                raise
+        self.ping()  # check connected
+
+    def disconnect(self):
+        self.disconnecting = True
+        try:
+            self.send_query('disconnect')
+        finally:
+            self.sock.close()
+        self.sock = None
+
+    def shutdown(self):
+        self.send_query('shutdown')
+
+    def send_query(self, func, *args, **kwargs):
+        dpk = DataPack(func, self.eoaa, *args, **kwargs)
+        if self.pkey:
+            dpk.sign_message(self.pkey)
+        tracelog(CLIENTLOG, str(dpk))
+        if dpk.send(self.sock) == 0:
+            self.disconnecting = True
+
+    def wait_response(self) -> DataPack:
+        resp = self.buffer
+        assert len(resp) == 0  # XXX Uhmm how to control msg drived by peer...
+        while EOM not in resp:
+            tmp = self.sock.recv(BUFSIZ).decode()
+            if len(tmp) == 0:  # disconnected
+                self.disconnecting = True
+                raise Exception('Disconnected by peer')
+            resp += tmp
+        resp, left = resp.split(EOM, 1)
+        dpk = DataPack.from_string(resp)
+        tracelog(CLIENTLOG, '%X, %s, %s', dpk.code, dpk.args, dpk.kwargs)
+        self.buffer = left  # maybe no left message
+        return dpk
+
+    def _simple_query(self, query):
+        self.send_query(query)
+        resp = self.wait_response()
+        if resp.code == MCSErrno.OK:
+            return
+        raise Exception('Received error: {:X} {}'.format(resp.code, resp.kwargs.get('data')))
+
+    def ping(self):
+        self._simple_query('ping')
+
+    def login(self):
+        self._simple_query('login')
+
+    def new_solver(self, operator_address: Optional[ChecksumAddress], pluginfile=None
+                   ) -> ChecksumAddress:
+        fnt = Fernet(self._get_fernet_key())
+        enc_pkey = fnt.encrypt(self.pkey.encode('utf-8')).decode()
+        kwargs = {
+            'encrypted_pkey': enc_pkey,
+            'operator_address': operator_address,
+            'solver_plugin': pluginfile,
+        }
+        self.send_query('new_solver', **kwargs)
+        resp = self.wait_response()
+        if resp.code == MCSErrno.OK:
+            self.operator_address = resp.kwargs['operator_address']
+            self.solver_class = resp.kwargs['solver_class']
+            return self.operator_address
+        raise MCSError(code=cast(MCSErrno, resp.code), msg=resp.kwargs.get('data'))
+
+    def _get_fernet_key(self) -> bytes:
+        self.send_query('get_fernet_key')
+        resp = self.wait_response()
+        if resp.code == MCSErrno.OK:
+            return resp.kwargs['data'].encode('utf-8')
+        raise MCSError(code=cast(MCSErrno, resp.code), msg=resp.kwargs.get('data'))
+
+    def _solver_control(self, act) -> Optional[ChecksumAddress]:
+        assert act in ('get_solver', 'purge_solver')
+        self.send_query(act)
+        resp = self.wait_response()
+        if resp.code == MCSErrno.OK:
+            if act == 'get_solver':
+                self.operator_address = resp.kwargs.get('operator_address')
+                self.solver_class = resp.kwargs.get('solver_class')
+                return self.operator_address
+            return None
+        raise MCSError(code=cast(MCSErrno, resp.code), msg=resp.kwargs.get('data'))
+
+    def get_solver(self) -> ChecksumAddress:
+        ret = self._solver_control('get_solver')
+        return cast(ChecksumAddress, ret)
+
+    def purge_solver(self):
+        self._solver_control('purge_solver')
+
+    def solver(self, *args, **kwargs) -> Any:
+        assert len(args) > 0
+        self.send_query('solver', *args, **kwargs)
+        resp = self.wait_response()
+        if resp.code == MCSErrno.OK:
+            return resp.kwargs.get('data')
+        raise MCSError(code=cast(MCSErrno, resp.code), msg=resp.kwargs.get('data'))
+
+
+def mcs_console(eoaa, pkey):
+    """ Simple CUI to use MCSClient
+    """
+
+    client = MCSClient(eoaa, pkey)
+    try:
+        client.connect()
+    except Exception as err:
+        raise Exception('cannot connect to solver daemon') from err
+    sock = client.sock
+    msg = ''
+    while not client.disconnecting:
+
+        print('query? ', end='')
+
+        sys.stdout.flush()
+        try:
+            rfds, _, _ = select.select([sock, sys.stdin], [], [])
+
+            if sock in rfds:  # received message from peer
+                tmp = sock.recv(BUFSIZ).decode()
+                if len(tmp) == 0:  # disconnected
+                    break
+                msg += tmp
+                tracelog(CLIENTLOG, 'received: %s', tmp.strip())
+                queries = msg.split(EOM)
+                for query in queries[:-1]:
+                    if query in {'SHUTDOWN', 'DISCONNECT'}:
+                        client.disconnecting = True
+                        break  # immediately
+                msg = queries[-1]  # empty or incomplete msg
+                if client.disconnecting:
+                    break
+
+            if sys.stdin in rfds:  # got query from stdin
+                # input format:
+                #   query? <func_name>
+                # or
+                #   query? <func_name><tab><args and|or kwargs>
+                # format of <args and|or kwargs>:
+                #   {"args":["arg0", ...], "kwargs":{"key0":"val0",...}}
+                #
+                tokens = sys.stdin.readline().strip().split(ARGS_DELIMITER, 1)
+                func = tokens[0]
+                jval = json.loads(tokens[1] if len(tokens) > 1 else '{}')
+                try:
+                    resp = getattr(client, func)(
+                        *jval.get('args', []),
+                        **jval.get('kwargs', {}))
+                    print(resp)
+                    if func in {'shutdown', 'disconnect'}:
+                        break
+                except Exception as err:
+                    CLIENTLOG.exception(err)
+                    print(err)
+
+        except KeyboardInterrupt:
+            break
+    if sock:
+        sock.close()

--- a/metemcyber/core/multi_solver_cli.py
+++ b/metemcyber/core/multi_solver_cli.py
@@ -1,0 +1,79 @@
+#
+#    Copyright 2021, NTT Communications Corp.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+import argparse
+from typing import List, Tuple
+
+from web3 import Web3
+
+from metemcyber.core.bc.util import decode_keyfile
+from metemcyber.core.logger import get_logger
+from metemcyber.core.multi_solver import MCSServer, SolverManager, mcs_console
+
+LOGGER = get_logger(name='solver_client', file_prefix='core')
+
+
+def main(args):
+    if args.keyfile:
+        eoaa, pkey = decode_keyfile(args.keyfile)
+    else:
+        eoaa, pkey = args.name, args.pkey
+        if eoaa:
+            eoaa = Web3.toChecksumAddress(eoaa)
+    if args.operator:
+        if '@' in args.operator:
+            operator_address, pluginfile = args.operator.split('@', 1)
+        else:
+            operator_address = args.operator
+            pluginfile = ''
+    else:
+        operator_address = pluginfile = None
+
+    if args.mode == 'server':
+        mgr = SolverManager(args.endpoint_url, eoaa, pkey, operator_address, pluginfile)
+        server = MCSServer(mgr)
+        server.run()
+    else:
+        mcs_console(eoaa, pkey)
+
+
+OPTIONS: List[Tuple[str, str, dict]] = [
+    ('-m', '--mode', dict(
+        action='store', required=True,
+        choices=['server', 'client'])),
+    ('-f', '--keyfile', dict(
+        action='store', dest='keyfile',
+        help='キーファイル')),
+    ('-u', '--user', dict(
+        action='store', dest='name',
+        help='ログインユーザ(EOA Address)')),
+    ('-k', '--privatekey', dict(
+        action='store', dest='pkey',
+        help='プライベートキー')),
+    ('-e', '--endpoint', dict(
+        action='store', dest='endpoint_url',
+        help='Ethereum Provider Endpoint URL')),
+    ('-o', '--operator', dict(
+        action='store', dest='operator',
+        help='CTIOperatorContractAddress[@SolverPluginFilename]')),
+]
+
+if __name__ == '__main__':
+    PARSER = argparse.ArgumentParser()
+    for sname, lname, etc_opts in OPTIONS:
+        PARSER.add_argument(sname, lname, **etc_opts)
+    ARGS = PARSER.parse_args()
+    main(ARGS)

--- a/metemcyber/core/plugin.py
+++ b/metemcyber/core/plugin.py
@@ -1,0 +1,100 @@
+#
+#    Copyright 2021, NTT Communications Corp.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+import os
+import sys
+from importlib import import_module
+from typing import Any, Dict, Optional, Tuple, Type
+
+from eth_typing import ChecksumAddress
+
+from .bc.util import ADDRESS0
+from .logger import get_logger
+from .solver import BaseSolver
+
+LOGGER = get_logger(name='plugin', file_prefix='core')
+# the directory where plugins are placed
+PLUGINS_PATH = os.getenv('PLUGINS_PATH', './metemcyber/plugins')
+SOLVER_CLASSNAME = 'Solver'
+
+
+class PluginManager():
+
+    def __new__(cls, *_args, **_kwargs):
+        if not hasattr(cls, "_instance"):
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __init__(self):
+        #                   filename: module
+        self._modules: Dict[str, Any] = {}
+        #                   operator_address:     (solver_class,     filename)
+        self._solvers: Dict[ChecksumAddress, Tuple[Type[BaseSolver], str]] = {}
+
+    def load(self, path: str = PLUGINS_PATH) -> None:
+        if self._modules:
+            LOGGER.debug('Plugin: already loaded')
+            return
+
+        # prepare for import_module
+        sys.path.insert(0, path)
+
+        for fname in os.listdir(path):
+            filepath = '{}/{}'.format(path, fname)
+            if not (os.path.isfile(filepath) and fname.endswith('.py')):
+                continue
+            try:
+                mod_name = os.path.splitext(fname)[0]
+                mod = import_module(mod_name)
+                if hasattr(mod, SOLVER_CLASSNAME):
+                    self._modules[fname] = mod
+                    LOGGER.info('loaded %s from %s', SOLVER_CLASSNAME, fname)
+            except Exception as err:
+                LOGGER.exception(err)
+
+        sys.path.remove(path)
+        LOGGER.debug(self._modules)
+
+    def set_default_solverclass(self, plugin_filename: str) -> None:
+        self.set_solverclass(ADDRESS0, plugin_filename)
+
+    def set_solverclass(self, operator_address: ChecksumAddress, plugin_filename: str) -> None:
+        if plugin_filename not in self._modules.keys():
+            raise Exception('No such plugin loaded: ' + plugin_filename)
+        mod = self._modules[plugin_filename]
+        if not hasattr(self._modules[plugin_filename], SOLVER_CLASSNAME):
+            raise Exception('Not a solver: ' + plugin_filename)
+        solver = getattr(self._modules[plugin_filename], SOLVER_CLASSNAME)
+        self._solvers[operator_address] = (solver, plugin_filename)
+        LOGGER.info(
+            'Set solverclass %s.%s for operator %s',
+            mod.__name__, solver.__name__, operator_address)
+
+    def get_solverclass(self, operator_address: ChecksumAddress) -> Type[BaseSolver]:
+        if operator_address in self._solvers.keys():
+            return self._solvers[operator_address][0]
+        if ADDRESS0 in self._solvers.keys():
+            # return default if set.
+            return self._solvers[ADDRESS0][0]
+        return BaseSolver
+
+    def get_plugin_filename(self, operator_address: ChecksumAddress) -> Optional[str]:
+        if operator_address in self._solvers.keys():
+            return self._solvers[operator_address][1]
+        return None
+
+    def is_pluginfile(self, filename: str) -> bool:
+        return filename in self._modules.keys()

--- a/metemcyber/core/seeker.py
+++ b/metemcyber/core/seeker.py
@@ -1,0 +1,181 @@
+#
+#    Copyright 2021, NTT Communications Corp.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+import json
+import os
+import sys
+from signal import SIGINT
+from subprocess import Popen
+from time import sleep
+from typing import List, Optional, Tuple
+from urllib.request import Request, urlopen
+
+from eth_typing import ChecksumAddress
+from psutil import NoSuchProcess, Process
+from werkzeug.datastructures import EnvironHeaders
+
+from metemcyber.core.bc.util import verify_message
+from metemcyber.core.logger import get_logger
+from metemcyber.core.webhook import WebhookReceiver
+
+LOGGER = get_logger(name='seeker', file_prefix='core')
+
+DOWNLOADED_CTI_PATH = './download'  # FIXME: should import from somewhere
+SEEKER_PID_FILEPATH = './seeker.pid'  # FIXME
+
+
+def download_json(download_url: str, token_address: ChecksumAddress) -> None:
+    try:
+        request = Request(download_url, method='GET')
+        with urlopen(request) as response:
+            rdata = response.read()
+    except Exception as err:
+        LOGGER.exception(err)
+        LOGGER.error(f'Failed download from {download_url}.')
+        return
+
+    try:
+        jdata = json.loads(rdata)
+        title = jdata['Event']['info']
+    except Exception:
+        title = '(cannot decode title)'
+    LOGGER.info(f'Downloaded data, title: {title}.')
+
+    try:
+        if not os.path.isdir(DOWNLOADED_CTI_PATH):
+            os.makedirs(DOWNLOADED_CTI_PATH)
+        filepath = f'{DOWNLOADED_CTI_PATH}/{token_address}.json'
+        with open(filepath, 'wb') as fout:
+            fout.write(rdata)
+        LOGGER.info(f'Saved downloaded data in {filepath}.')
+    except Exception as err:
+        LOGGER.exception(err)
+        LOGGER.error('Saving downloaded data failed.')
+
+
+class Resolver(WebhookReceiver):
+    @staticmethod
+    def resolve_request(headers: EnvironHeaders, body: str) -> None:
+        sign = headers.get('MetemcyberSignature')
+        if sign is None:
+            LOGGER.error(f'Received request without signature. headers={headers}, body={body}.')
+            return
+        try:
+            LOGGER.debug(f'Received request. headers={headers}, body={body}.')
+            signer = verify_message(body, sign)
+            LOGGER.debug(f'Calculated signer is {signer}.')
+        except Exception as err:
+            LOGGER.exception(err)
+            LOGGER.error('Verify message failed')
+        try:
+            jdata = json.loads(body)
+            download_url = jdata['download_url']
+            token_address = jdata['token_address']
+            assert download_url
+            assert token_address
+
+            #
+            # FIXME: check signer is the owner of this token.
+            #
+
+        except Exception as err:
+            LOGGER.exception(err)
+            LOGGER.error('Decoding request body failed.')
+            return
+        LOGGER.info(f'Received download_url for token({token_address}): {download_url}')
+        download_json(download_url, token_address)
+
+
+class Seeker():
+    cmd_args_base = ['python3', 'metemcyber/core/seeker.py']
+
+    @property
+    def cmd_args(self) -> List[str]:
+        if self.local:
+            return Seeker.cmd_args_base + ['127.0.0.1', '0']
+        return Seeker.cmd_args_base + ['0.0.0.0', '0']
+
+    @staticmethod
+    def check_running() -> Tuple[int, Optional[str], int]:  # (pid|0, listen_address, listen_port)
+        try:
+            with open(SEEKER_PID_FILEPATH, 'r') as fin:
+                str_data = fin.readline().strip()
+            str_pid, address, str_port = str_data.split('\t', 2)
+            pid = int(str_pid)
+        except Exception:
+            return 0, None, 0
+        try:
+            proc = Process(pid)
+            if proc.cmdline()[:len(Seeker.cmd_args_base)] == Seeker.cmd_args_base:
+                return pid, address, int(str_port)
+            # found pid, but it's not a seeker. remove defunct data.
+            LOGGER.info(f'got pid({pid}) which is not a seeker. remove defunct.')
+            os.unlink(SEEKER_PID_FILEPATH)
+            return 0, None, 0
+        except NoSuchProcess:
+            return 0, None, 0
+
+    def __init__(self, local: bool = True) -> None:
+        self.local: bool = local
+        pid, address, port = self.check_running()
+        self.pid: int = pid
+        self.address: Optional[str] = address
+        self.port: int = port
+
+    def start(self) -> None:
+        """launch Resolver by calling main() as another process
+        """
+        if self.pid:
+            raise Exception(f'Already running on pid({self.pid}).')
+        proc = Popen(self.cmd_args, shell=False)
+        for _cnt in range(5):
+            sleep(1)
+            self.pid, self.address, self.port = self.check_running()
+            if self.pid:
+                LOGGER.info(f'started. pid={self.pid}, address={self.address}, port={self.port}.')
+                return
+        LOGGER.error('Cannot start webhook.')
+        proc.kill()
+        raise Exception('Cannot start webhook')
+
+    def stop(self) -> None:
+        pid, _address, _port = self.check_running()
+        if not pid:
+            raise Exception('Not running')
+        try:
+            LOGGER.info(f'stopping process({pid}).')
+            os.kill(pid, SIGINT)
+        except Exception as err:
+            raise Exception(f'Cannot stop webhook(pid={pid})') from err
+
+
+def main(listen_address: str, listen_port: str):
+    try:
+        resolver = Resolver(listen_address, int(listen_port))
+        address, port = resolver.start()
+        pid = os.getpid()
+        with open(SEEKER_PID_FILEPATH, 'w') as fout:
+            fout.write(f'{pid}\t{address}\t{port}\n')
+        assert resolver.thread
+        resolver.thread.join()
+    except KeyboardInterrupt:
+        LOGGER.info('caught SIGINT.')
+    finally:
+        os.unlink(SEEKER_PID_FILEPATH)
+
+
+if __name__ == '__main__':
+    main(sys.argv[1], sys.argv[2])

--- a/metemcyber/core/solver.py
+++ b/metemcyber/core/solver.py
@@ -1,0 +1,167 @@
+#
+#    Copyright 2021, NTT Communications Corp.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+import json
+from typing import Any, Callable, Dict, List, Optional
+from urllib.request import Request, urlopen
+
+from eth_typing import ChecksumAddress
+from eth_utils.exceptions import ValidationError
+from requests.exceptions import HTTPError
+from web3.datastructures import AttributeDict
+
+from .bc.account import Account
+from .bc.cti_operator import CTIOperator
+from .bc.eventlistener import BasicEventListener
+from .logger import get_logger
+
+LOGGER = get_logger(name='solver', file_prefix='core.bc')
+
+
+class ChallengeListener(BasicEventListener):
+    def __init__(self, account: Account, operator: ChecksumAddress, event_name: str) -> None:
+        super().__init__(str(self))
+        #                    token_address:   callback(token_address,    event)
+        self.accepting: Dict[ChecksumAddress, Callable[[ChecksumAddress, AttributeDict[Any, Any]],
+                                                       None]] = {}
+        event_filter = CTIOperator(account).get(
+            operator).event_filter(event_name, fromBlock='latest')
+        self.add_event_filter(f'{event_name}:{operator}', event_filter, self.dispatch_callback)
+
+    def dispatch_callback(self, event: AttributeDict[Any, Any]) -> None:
+        token_address = event['args']['token']
+        if token_address in self.accepting.keys():
+            callback = self.accepting[token_address]
+            callback(token_address, event)
+
+    def accept_tokens(self, token_addresses: List[ChecksumAddress],
+                      callback: Callable[[ChecksumAddress, AttributeDict[Any, Any]], None]) -> None:
+        for address in token_addresses:
+            self.accepting[address] = callback
+
+    def refuse_tokens(self, token_addresses: List[ChecksumAddress]) -> None:
+        for address in token_addresses:
+            self.accepting.pop(address, None)
+
+    def list_accepting(self) -> List[ChecksumAddress]:
+        return list(self.accepting.keys())
+
+
+class BaseSolver:
+    def __init__(self, account: Account, operator_address: ChecksumAddress) -> None:
+        LOGGER.info('initializing solver %s for %s', self, operator_address)
+        self.account: Account = account
+        self.operator_address: ChecksumAddress = operator_address
+        self.listener: Optional[ChallengeListener] = None
+
+    def destroy(self):
+        LOGGER.info('destructing solver %s for %s', self, self.operator_address)
+        if self.listener:
+            self.listener.destroy()
+            self.listener = None
+
+    @staticmethod  # should be overwritten by subclass
+    def notify_first_accept():
+        return None
+
+    def accepting_tokens(self):
+        return self.listener.list_accepting() if self.listener else []
+
+    def accept_registered(self, tokens):
+        LOGGER.info('accept_registered candidates: %s', tokens)
+        registered = CTIOperator(self.account).get(self.operator_address).check_registered(tokens)
+        accepting = self.accepting_tokens()
+        targets = [
+            token for i, token in enumerate(tokens)
+            if registered[i] and token not in accepting]
+        if targets:
+            LOGGER.info('newly accepted: %s', targets)
+            msg = self._accept(targets, force_register=False)
+            self.reemit_pending_tasks(targets)
+            return msg
+        return None
+
+    def accept_challenges(self, tokens):
+        LOGGER.info('BaseSolver: accept tokens: %s', tokens)
+        accepting = self.accepting_tokens()
+        targets = [token for token in tokens if token not in accepting]
+        if targets:
+            msg = self._accept(targets, force_register=True)
+            self.reemit_pending_tasks(targets)
+            return msg
+        return None
+
+    def _accept(self, token_addresses, force_register=False):
+        if len(token_addresses) == 0:
+            return None
+        need_notify = \
+            self.listener is None or len(self.listener.accepting) == 0
+        if not self.listener:
+            self.listener = ChallengeListener(
+                self.account, self.operator_address, 'TokensReceivedCalled')
+            self.listener.start()
+        self.listener.accept_tokens(token_addresses, self.process_challenge)
+        if force_register:
+            CTIOperator(self.account).get(self.operator_address).register_tokens(token_addresses)
+        return self.notify_first_accept() if need_notify else None
+
+    def refuse_challenges(self, token_addresses):
+        LOGGER.info('BaseSolver: refuse: %s', token_addresses)
+        if self.listener:
+            self.listener.refuse_tokens(token_addresses)
+        CTIOperator(self.account).get(self.operator_address).unregister_tokens(token_addresses)
+
+    def accept_task(self, task_id):
+        try:
+            CTIOperator(self.account).get(self.operator_address).accept_task(task_id)
+            return True
+        except (HTTPError, ValueError, ValidationError) as err:
+            # another solver may accept faster than me.
+            LOGGER.error(err)
+            return False
+
+    def finish_task(self, task_id, data=''):
+        CTIOperator(self.account).get(self.operator_address).finish_task(task_id, data)
+
+    def reemit_pending_tasks(self, tokens):
+        CTIOperator(self.account).get(self.operator_address).reemit_pending_tasks(tokens)
+
+    @staticmethod
+    def process_challenge(_token_address, _event):
+        print('チャレンジの実装、または設定がありません')
+
+        # need your code as a plug-in. see plugins/*solver.py as examples.
+        # 1. preparation if needed.
+        # 2. accept_task. task_id is given in event['args']['taskId'].
+        # 3. your own process to solve request.
+        # 4. return result via webhook.
+        #    url can be gotten by Web3.toText(event['args']['data'].
+        # 5. finish_task.
+
+    def webhook(self, url, download_url, token_address):
+        data_obj = {
+            "download_url": download_url,
+            "token_address": token_address
+        }
+        data = json.dumps(data_obj)
+        sign = self.account.sign_message(str(data))
+        headers = {"Content-Type": "application/json",
+                   "MetemcyberSignature": sign}
+        # httpリクエストを準備してPOST
+        request = Request(url, data=data.encode('utf-8'), method="POST", headers=headers)
+        with urlopen(request) as response:
+            LOGGER.info(response.getcode())
+            LOGGER.debug(response.info())

--- a/metemcyber/core/util.py
+++ b/metemcyber/core/util.py
@@ -1,0 +1,36 @@
+#
+#    Copyright 2021, NTT Communications Corp.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+from random import randint
+
+LOCAL_PORT_RANGE_FILE = '/proc/sys/net/ipv4/ip_local_port_range'
+LOCAL_PORT_MIN = 0
+LOCAL_PORT_MAX = 0
+
+
+def get_random_local_port() -> int:
+    # pylint: disable=global-statement
+    global LOCAL_PORT_MIN, LOCAL_PORT_MAX
+    if LOCAL_PORT_MAX == 0:
+        try:
+            with open(LOCAL_PORT_RANGE_FILE, 'r') as fin:
+                p_min, p_max = fin.readline().strip().split('\t', 1)
+                LOCAL_PORT_MIN = int(p_min)
+                LOCAL_PORT_MAX = int(p_max)
+        except Exception:
+            LOCAL_PORT_MIN = 50000
+            LOCAL_PORT_MAX = 59999
+    return randint(LOCAL_PORT_MIN, LOCAL_PORT_MAX)

--- a/metemcyber/core/webhook.py
+++ b/metemcyber/core/webhook.py
@@ -1,0 +1,101 @@
+#
+#    Copyright 2021, NTT Communications Corp.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+import logging
+import os
+import sys
+from threading import Thread
+from time import sleep
+from typing import Callable, Optional, Tuple
+
+from flask import Flask, request
+from werkzeug.datastructures import EnvironHeaders
+
+from .util import get_random_local_port
+
+RANDOM_PORT_RETRY_MAX = 10
+
+os.environ['WERKZEUG_RUN_MAIN'] = 'true'  # eliminate werkzeug server banner on boot
+logging.getLogger('werkzeug').disabled = True
+
+
+class WebhookReceiver():
+    def __init__(self, address: str, port: int,
+                 callback: Optional[Callable[[EnvironHeaders, str], None]] = None) -> None:
+        assert port >= 0
+        self.address: str = address
+        self.port: int = port
+        self.callback: Callable[[EnvironHeaders, str],
+                                None] = callback if callback else self.resolve_request
+        self.thread: Optional[Thread] = None
+
+    def start(self) -> Tuple[str, int]:
+        if self.thread:
+            raise Exception('Already running')
+        self.thread = Thread(target=self.boot_server, daemon=True)
+        self.thread.start()
+        sleep(1)
+        assert self.thread
+        assert self.thread.is_alive()
+        return self.address, self.port
+
+    def boot_server(self) -> None:
+        app = Flask(self.__class__.__name__)
+        app.add_url_rule('/', 'post_callback', self._data_dispatcher, methods=['POST'])
+        if self.port > 0:
+            app.run(self.address, self.port)
+            return
+        retry = RANDOM_PORT_RETRY_MAX
+        while True:
+            try:
+                self.port = get_random_local_port()
+                app.run(self.address, self.port)
+            except OSError as err:
+                if err.errno == 98:  # Address already in use
+                    retry -= 1
+                    if retry > 0:
+                        continue
+                    raise Exception('Cannot get unused port') from err
+            break
+        self.thread = None
+
+    def _data_dispatcher(self) -> str:
+        headers = request.headers
+        body = request.get_data(cache=False, as_text=True)  # XXX: should decode as text?
+        Thread(target=self.callback, args=[headers, body], daemon=True).start()
+        return 'ok'
+
+    @staticmethod
+    def resolve_request(headers: EnvironHeaders, body: str) -> None:
+        print(headers)
+        print('--')
+        print(body)
+
+
+def main(listen_address: str, listen_port: str):
+    try:
+        webhook = WebhookReceiver(listen_address, int(listen_port))
+        address, port = webhook.start()
+        pid = os.getpid()
+        print(f'{pid}\t{address}\t{port}')
+        assert webhook.thread
+        webhook.thread.join()
+    except KeyboardInterrupt:
+        print('caught SIGINT.')
+
+
+if __name__ == '__main__':
+    main(sys.argv[1], sys.argv[2])

--- a/metemcyber/plugins/gcs_solver.py
+++ b/metemcyber/plugins/gcs_solver.py
@@ -1,0 +1,103 @@
+#
+#    Copyright 2020, NTT Communications Corp.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+import os
+
+import requests
+from web3 import Web3
+
+from metemcyber.core.logger import get_logger
+from metemcyber.core.solver import BaseSolver
+
+LOGGER = get_logger(name='gcs_solver', file_prefix='core')
+FILESERVER_ASSETS_PATH = os.getenv('FILESERVER_ASSETS_PATH', 'workspace/dissemination')  # FIXME
+FUNCTIONS_URL = os.getenv("FUNCTIONS_URL", "")
+FUNCTIONS_TOKEN = os.getenv("FUNCTIONS_TOKEN", "")
+
+
+class Solver(BaseSolver):
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.uploader = Uploader()
+
+    def notify_first_accept(self):
+        if FUNCTIONS_URL:
+            return \
+                'Solver として受付を開始しました。\n' + \
+                'チャレンジ結果は中継点( {} )にアップロードされます'.\
+                format(FUNCTIONS_URL)
+        return 'Solver用のURLが設定されていません。'
+
+    def process_challenge(self, token_address, event):
+        LOGGER.info('GCSSolver: callback: %s', token_address)
+        LOGGER.debug(event)
+
+        task_id = event['args']['taskId']
+        challenge_seeker = event['args']['from']
+        LOGGER.info(
+            'accepting task %s from seeker %s', task_id, challenge_seeker)
+        if not self.accept_task(task_id):
+            LOGGER.warning('could not accept task %s', task_id)
+            return
+
+        LOGGER.info('accepted task %s', task_id)
+        data = ''
+        try:
+            try:
+                download_url = self.upload_to_storage(token_address)
+                url = Web3.toText(event['args']['data'])
+            except Exception:
+                data = 'Challenge failed by solver side error'
+                raise
+            try:
+                # return answer via webhook
+                self.webhook(url, download_url, token_address)
+            except Exception as err:
+                data = 'cannot sendback result via webhook: ' + str(err)
+                raise
+        except Exception as err:
+            LOGGER.exception(err)
+            LOGGER.error('failed task %s', task_id)
+        finally:
+            self.finish_task(task_id, data)
+            LOGGER.info('finished task %s', task_id)
+
+    def upload_to_storage(self, cti_address):
+        file_path = os.path.abspath('{}/{}'.format(
+            FILESERVER_ASSETS_PATH, cti_address))
+        url = self.uploader.upload_file(file_path)
+        return url
+
+
+class Uploader:
+    @staticmethod
+    def upload_file(upload_path):
+        if not FUNCTIONS_URL:
+            LOGGER.error('There are no settings for upload URL')
+            return None
+
+        headers = {
+            'Authorization': 'Bearer {}'.format(FUNCTIONS_TOKEN),
+            'Content-Type': 'application/json'}
+        response = requests.post(
+            FUNCTIONS_URL,
+            data=open(upload_path, 'rb'),
+            headers=headers)
+        results = response.json()
+        if 'result' in results:
+            return results['result']
+        LOGGER.error('File upload Error: %s', results['error'])
+        return None

--- a/metemcyber/plugins/standalone_solver.py
+++ b/metemcyber/plugins/standalone_solver.py
@@ -1,0 +1,144 @@
+#
+#    Copyright 2020, NTT Communications Corp.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+import os
+import socket
+from http.server import SimpleHTTPRequestHandler
+from socketserver import TCPServer
+from threading import Thread
+
+from web3 import Web3
+
+from metemcyber.core.logger import get_logger
+from metemcyber.core.solver import BaseSolver
+from metemcyber.core.util import get_random_local_port
+
+LOGGER = get_logger(name='standaone_solver', file_prefix='core')
+
+FILESERVER_ASSETS_PATH = os.getenv('FILESERVER_ASSET_PATH', 'workspace/dissemination')  # FIXME
+CONTENTS_ROOT = FILESERVER_ASSETS_PATH
+LISTEN_ADDR = ''
+GET_RANDOM_RETRY_MAX = 10
+JOIN_TIMEOUT_SEC = 30
+
+
+class SimpleHandler(SimpleHTTPRequestHandler):
+    def __init__(self, *args):
+        self.logpref = 'LocalHttpServer'
+        SimpleHTTPRequestHandler.__init__(self, *args, directory=CONTENTS_ROOT)
+
+    def do_GET(self):
+        SimpleHTTPRequestHandler.do_GET(self)
+
+    def log_error(self, *args):
+        LOGGER.error(self.logpref + ': ' + args[0], *args[1:])
+
+    def log_message(self, *args):
+        LOGGER.info(self.logpref + ': ' + args[0], *args[1:])
+
+
+class LocalHttpServer():
+    def __init__(self, identity):
+        self.identity = identity
+        self.thread = None
+        self.server = None
+        self.addr = LISTEN_ADDR
+        self.port = 0
+        self.handler = SimpleHandler
+
+    def start(self):
+        if self.thread:
+            return
+        self.thread = Thread(target=self.run, daemon=True)
+        self.thread.start()
+
+    def run(self):
+        for _count in range(GET_RANDOM_RETRY_MAX):
+            try:
+                self.port = get_random_local_port()
+                LOGGER.info(
+                    '%s: starting httpd: %s at %s:%d',
+                    self.__class__.__name__, self.identity, self.addr, self.port)
+                with TCPServer((self.addr, self.port), self.handler) as httpd:
+                    self.server = httpd
+                    httpd.serve_forever()
+                LOGGER.info('%s: stopped httpd: %s', self.__class__.__name__, self.identity)
+                return
+            except OSError as err:
+                if err.errno == 98:  # EADDRINUSE (address already in use)
+                    continue
+                raise
+        raise Exception("cannot assign listen port for httpd")
+
+    def stop(self):
+        if self.server:
+            self.server.shutdown()
+            self.server = None
+        if self.thread:
+            self.thread.join(timeout=JOIN_TIMEOUT_SEC)
+            if self.thread.is_alive():
+                LOGGER.error('failed stopping httpd: %s', self.identity)
+            self.thread = None
+
+
+class Solver(BaseSolver):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fileserver = LocalHttpServer(self.account.eoa)
+        self.fileserver.start()
+
+    def destroy(self):
+        super().destroy()
+        if self.fileserver:
+            self.fileserver.stop()
+            self.fileserver = None
+
+    def process_challenge(self, token_address, event):
+        LOGGER.info('StandaloneSolver: callback: %s', token_address)
+        LOGGER.debug(event)
+
+        task_id = event['args']['taskId']
+        challenge_seeker = event['args']['from']
+        LOGGER.info(
+            'accepting task %s from seeker %s', task_id, challenge_seeker)
+        if not self.accept_task(task_id):
+            LOGGER.warning('could not accept task %s', task_id)
+            return
+
+        LOGGER.info('accepted task %s', task_id)
+        data = ''
+        try:
+            # process for Demo
+            download_url = self.create_misp_download_url(token_address)
+            url = Web3.toText(event['args']['data'])
+
+            # return answer via webhook
+            LOGGER.info('returning answer to %s', url)
+            self.webhook(url, download_url, token_address)
+        except Exception as err:
+            data = str(err)
+            LOGGER.exception(err)
+            LOGGER.error('failed task %s', task_id)
+        finally:
+            self.finish_task(task_id, data)
+            LOGGER.info('finished task %s', task_id)
+
+    def create_misp_download_url(self, cti_address):
+        url = 'http://{host}:{port}/{path}'.format(
+            host=socket.gethostname(),
+            port=self.fileserver.port,
+            path=cti_address)
+        return url

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -15,3 +15,4 @@ rusty-rlp
 docopt==0.6.2
 kedro==0.17.0
 typer==0.3.2
+psutil

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -16,3 +16,4 @@ docopt==0.6.2
 kedro==0.17.0
 typer==0.3.2
 psutil
+cryptography


### PR DESCRIPTION
seeker と solver を実装しました。まだ「使える」レベルには少し足りませんので追って追加します。
- それぞれ、サブプロセスの制御を含みます。
- seeker は、チャレンジ実行時に指定する webhook url の生成（の補助）機能を追加予定です。
- solver は、register, unregister の制御機能が（metemctl には）未実装です。この後追加します。
- 従来 metemcyber.settings 辺りから参照されていた値などをどうするか、要検討です。（暫定でハードコードしたり、読めないまま放置してたりします）
- cli/cli.py が 1000 行を超えたので pylint が怒ってます。これは想定通りの認識なので、cli.py 内で disable=too-many-line してます。
- solver プロセスに private key を渡してやる必要があるのですが、よい方法が見つけられていません。差し当たり、生データはログに残らないようにしましたが、ログとコードがあれば簡単に復号できます。一応、案はあるので、後で改修します。
- 上記用途の可逆暗号に cryptography, サブプロセス制御に psutils、のパッケージを追加しています。