### PR TITLE
Topic/enhance configs

### DIFF
--- a/metemcyber/cli/cli.py
+++ b/metemcyber/cli/cli.py
@@ -604,7 +604,7 @@ def token_create(ctx: typer.Context, initial_supply: int):
 def seeker_status(_ctx: typer.Context):
     logger = getLogger()
     try:
-        seeker = Seeker()
+        seeker = Seeker(APP_DIR)
         if seeker.pid == 0:
             typer.echo(f'not running.')
         else:
@@ -616,10 +616,10 @@ def seeker_status(_ctx: typer.Context):
 
 @seeker_app.command('start')
 def seeker_start(_ctx: typer.Context,
-                 local: bool = typer.Option(True, help='listen localhost only')):
+                 config: Optional[str] = typer.Option(None, help='seeker config filepath')):
     logger = getLogger()
     try:
-        seeker = Seeker(local)
+        seeker = Seeker(APP_DIR, config)
         seeker.start()
         typer.echo(f'seeker started on process {seeker.pid}, '
                    f'listening {seeker.address}:{seeker.port}.')
@@ -632,7 +632,7 @@ def seeker_start(_ctx: typer.Context,
 def seeker_stop(_ctx: typer.Context):
     logger = getLogger()
     try:
-        seeker = Seeker()
+        seeker = Seeker(APP_DIR)
         seeker.stop()
         typer.echo(f'seeker stopped.')
     except Exception as err:
@@ -716,7 +716,7 @@ def solver_stop(ctx: typer.Context):
                     help='Solver start running with operator you configured.')
 def solver_enable(ctx: typer.Context,
                   plugin: Optional[str] = typer.Option(None, help='solver plugin filename'),
-                  config: Optional[str] = typer.Option(None, help='solver config filename')):
+                  config: Optional[str] = typer.Option(None, help='solver config filepath')):
     logger = getLogger()
     try:
         operator = _load_operator(ctx)

--- a/metemcyber/cli/cli.py
+++ b/metemcyber/cli/cli.py
@@ -134,7 +134,10 @@ def _get_keyfile_password() -> str:
     if word:
         return word
     typer.echo('You can also use an env METEMCTL_KEYFILE_PASSWORD.')
-    return typer.prompt('Enter password for keyfile', hide_input=True)
+    try:
+        return typer.prompt('Enter password for keyfile', hide_input=True)
+    except Exception as err:
+        raise Exception('Interrupted') from err  # click.exceptions.Abort has no message
 
 
 def _load_account(ctx: typer.Context) -> Account:

--- a/metemcyber/cli/cli.py
+++ b/metemcyber/cli/cli.py
@@ -715,12 +715,13 @@ def solver_stop(ctx: typer.Context):
 @solver_app.command('enable',
                     help='Solver start running with operator you configured.')
 def solver_enable(ctx: typer.Context,
-                  plugin: Optional[str] = typer.Option(None, help='solver plugin filename')):
+                  plugin: Optional[str] = typer.Option(None, help='solver plugin filename'),
+                  config: Optional[str] = typer.Option(None, help='solver config filename')):
     logger = getLogger()
     try:
         operator = _load_operator(ctx)
         solver = _solver_client(ctx)
-        applied = solver.new_solver(operator.address, pluginfile=plugin)
+        applied = solver.new_solver(operator.address, pluginfile=plugin, configfile=config)
         assert applied == operator.address
         typer.echo(f'Solver is now running with your operator({applied}).')
     except Exception as err:

--- a/metemcyber/cli/cli.py
+++ b/metemcyber/cli/cli.py
@@ -41,6 +41,7 @@ from metemcyber.core.bc.ether import Ether
 from metemcyber.core.bc.metemcyber_util import MetemcyberUtil
 from metemcyber.core.bc.operator import TASK_STATES, Operator
 from metemcyber.core.bc.token import Token
+from metemcyber.core.bc.util import ADDRESS0
 from metemcyber.core.logger import get_logger
 from metemcyber.core.multi_solver import MCSClient, MCSErrno, MCSError
 from metemcyber.core.seeker import Seeker
@@ -837,9 +838,8 @@ def _get_challenges(ctx: typer.Context
     raw_tasks = []
     limit_atonce = 16
     offset = 0
-    address0 = cast(ChecksumAddress, '0x{:040x}'.format(0))  # address(0): wildcard in history()
     while True:
-        tmp = operator.history(address0, limit_atonce, offset)
+        tmp = operator.history(ADDRESS0, limit_atonce, offset)
         raw_tasks.extend(tmp)
         if len(tmp) < limit_atonce:
             break

--- a/metemcyber/core/multi_solver.py
+++ b/metemcyber/core/multi_solver.py
@@ -169,7 +169,9 @@ class SolverManager():
 
     def destroy(self):
         for solver in [v['solver'] for v in self.solvers.values()]:
-            solver.destroy()
+            if solver:
+                solver.destroy()
+        self.solvers = {}
 
     def new_solver(self, eoaa: ChecksumAddress,
                    encrypted_pkey: str,
@@ -224,7 +226,7 @@ class SolverManager():
 
     def _solver_control(self, eoaa: ChecksumAddress, act: str) -> Optional[BaseSolver]:
         cache = self.solvers.get(eoaa)
-        if not cache:
+        if not cache or not cache['solver']:
             raise MCSError(MCSErrno.ENOENT, 'Not found')
         if not Web3.isChecksumAddress(eoaa):
             raise MCSError(MCSErrno.EINVAL, 'Not a checksum address')

--- a/metemcyber/core/multi_solver.py
+++ b/metemcyber/core/multi_solver.py
@@ -174,7 +174,8 @@ class SolverManager():
     def new_solver(self, eoaa: ChecksumAddress,
                    encrypted_pkey: str,
                    operator_address: Optional[ChecksumAddress],
-                   solver_plugin: Optional[str] = None
+                   solver_plugin: Optional[str] = None,
+                   solver_config: Optional[str] = None,
                    ) -> BaseSolver:
         cache = self.solvers.get(eoaa)
         if not cache or not cache['fernet_key']:
@@ -199,7 +200,7 @@ class SolverManager():
         if solver_plugin:
             self.plugin.set_solverclass(operator_address, solver_plugin)
         solverclass = self.plugin.get_solverclass(operator_address)
-        solver = solverclass(account, operator_address)
+        solver = solverclass(account, operator_address, solver_config)
 
         cache['solver'] = solver
         cache['account'] = account
@@ -549,7 +550,8 @@ class MCSClient():
     def login(self):
         self._simple_query('login')
 
-    def new_solver(self, operator_address: Optional[ChecksumAddress], pluginfile=None
+    def new_solver(self, operator_address: Optional[ChecksumAddress],
+                   pluginfile: Optional[str] = None, configfile: Optional[str] = None,
                    ) -> ChecksumAddress:
         fnt = Fernet(self._get_fernet_key())
         enc_pkey = fnt.encrypt(self.pkey.encode('utf-8')).decode()
@@ -557,6 +559,7 @@ class MCSClient():
             'encrypted_pkey': enc_pkey,
             'operator_address': operator_address,
             'solver_plugin': pluginfile,
+            'solver_config': configfile,
         }
         self.send_query('new_solver', **kwargs)
         resp = self.wait_response()

--- a/metemcyber/core/seeker.py
+++ b/metemcyber/core/seeker.py
@@ -29,6 +29,7 @@ from werkzeug.datastructures import EnvironHeaders
 
 from metemcyber.core.bc.util import verify_message
 from metemcyber.core.logger import get_logger
+from metemcyber.core.solver import SIGNATURE_HEADER
 from metemcyber.core.webhook import WebhookReceiver
 
 LOGGER = get_logger(name='seeker', file_prefix='core')
@@ -69,7 +70,7 @@ def download_json(download_url: str, token_address: ChecksumAddress) -> None:
 class Resolver(WebhookReceiver):
     @staticmethod
     def resolve_request(headers: EnvironHeaders, body: str) -> None:
-        sign = headers.get('MetemcyberSignature')
+        sign = headers.get(SIGNATURE_HEADER)
         if sign is None:
             LOGGER.error(f'Received request without signature. headers={headers}, body={body}.')
             return

--- a/metemcyber/core/seeker.py
+++ b/metemcyber/core/seeker.py
@@ -30,15 +30,26 @@ from werkzeug.datastructures import EnvironHeaders
 from metemcyber.core.bc.util import verify_message
 from metemcyber.core.logger import get_logger
 from metemcyber.core.solver import SIGNATURE_HEADER
+from metemcyber.core.util import merge_config
 from metemcyber.core.webhook import WebhookReceiver
 
 LOGGER = get_logger(name='seeker', file_prefix='core')
 
-DOWNLOADED_CTI_PATH = './download'  # FIXME: should import from somewhere
-SEEKER_PID_FILEPATH = './seeker.pid'  # FIXME
+CONFIG_SECTION = 'seeker'
+DEFAULT_CONFIGS = {
+    CONFIG_SECTION: {
+        'downloaded_cti_path': './download',
+        'listen_address': '127.0.0.1',
+        'listen_port': '0',
+    }
+}
 
 
-def download_json(download_url: str, token_address: ChecksumAddress) -> None:
+def seeker_pid_filepath(app_dir: str) -> str:
+    return f'{app_dir}/seeker.pid'
+
+
+def download_json(download_url: str, token_address: ChecksumAddress, dir_path: str) -> None:
     try:
         request = Request(download_url, method='GET')
         with urlopen(request) as response:
@@ -56,9 +67,9 @@ def download_json(download_url: str, token_address: ChecksumAddress) -> None:
     LOGGER.info(f'Downloaded data, title: {title}.')
 
     try:
-        if not os.path.isdir(DOWNLOADED_CTI_PATH):
-            os.makedirs(DOWNLOADED_CTI_PATH)
-        filepath = f'{DOWNLOADED_CTI_PATH}/{token_address}.json'
+        if not os.path.isdir(dir_path):
+            os.makedirs(dir_path)
+        filepath = f'{dir_path}/{token_address}.json'
         with open(filepath, 'wb') as fout:
             fout.write(rdata)
         LOGGER.info(f'Saved downloaded data in {filepath}.')
@@ -68,8 +79,11 @@ def download_json(download_url: str, token_address: ChecksumAddress) -> None:
 
 
 class Resolver(WebhookReceiver):
-    @staticmethod
-    def resolve_request(headers: EnvironHeaders, body: str) -> None:
+    def __init__(self, listen_address: str, listen_port: int, download_path: str):
+        super().__init__(listen_address, listen_port)
+        self.download_path = download_path
+
+    def resolve_request(self, headers: EnvironHeaders, body: str):
         sign = headers.get(SIGNATURE_HEADER)
         if sign is None:
             LOGGER.error(f'Received request without signature. headers={headers}, body={body}.')
@@ -97,7 +111,7 @@ class Resolver(WebhookReceiver):
             LOGGER.error('Decoding request body failed.')
             return
         LOGGER.info(f'Received download_url for token({token_address}): {download_url}')
-        download_json(download_url, token_address)
+        download_json(download_url, token_address, self.download_path)
 
 
 class Seeker():
@@ -105,14 +119,28 @@ class Seeker():
 
     @property
     def cmd_args(self) -> List[str]:
-        if self.local:
-            return Seeker.cmd_args_base + ['127.0.0.1', '0']
-        return Seeker.cmd_args_base + ['0.0.0.0', '0']
+        args = Seeker.cmd_args_base + [
+            self.config[CONFIG_SECTION]['listen_address'],
+            self.config[CONFIG_SECTION]['listen_port'],
+            self.app_dir,
+        ]
+        if self.config_path:
+            args += [self.config_path]
+        return args
 
-    @staticmethod
-    def check_running() -> Tuple[int, Optional[str], int]:  # (pid|0, listen_address, listen_port)
+    def __init__(self, app_dir: str, config_path: Optional[str] = None) -> None:
+        self.app_dir = app_dir
+        self.config_path = config_path
+        self.config = merge_config(config_path, DEFAULT_CONFIGS)
+        pid, address, port = self.check_running()
+        self.pid: int = pid
+        self.address: Optional[str] = address
+        self.port: int = port
+
+    #                               (pid|0, listen_address, listen_port)
+    def check_running(self) -> Tuple[int, Optional[str], int]:
         try:
-            with open(SEEKER_PID_FILEPATH, 'r') as fin:
+            with open(seeker_pid_filepath(self.app_dir), 'r') as fin:
                 str_data = fin.readline().strip()
             str_pid, address, str_port = str_data.split('\t', 2)
             pid = int(str_pid)
@@ -124,17 +152,10 @@ class Seeker():
                 return pid, address, int(str_port)
             # found pid, but it's not a seeker. remove defunct data.
             LOGGER.info(f'got pid({pid}) which is not a seeker. remove defunct.')
-            os.unlink(SEEKER_PID_FILEPATH)
+            os.unlink(seeker_pid_filepath(self.app_dir))
             return 0, None, 0
         except NoSuchProcess:
             return 0, None, 0
-
-    def __init__(self, local: bool = True) -> None:
-        self.local: bool = local
-        pid, address, port = self.check_running()
-        self.pid: int = pid
-        self.address: Optional[str] = address
-        self.port: int = port
 
     def start(self) -> None:
         """launch Resolver by calling main() as another process
@@ -163,20 +184,30 @@ class Seeker():
             raise Exception(f'Cannot stop webhook(pid={pid})') from err
 
 
-def main(listen_address: str, listen_port: str):
+def main(listen_address: str, listen_port: int, app_dir: str, config_path: Optional[str]):
+    pid_file = seeker_pid_filepath(app_dir)
     try:
-        resolver = Resolver(listen_address, int(listen_port))
+        config = merge_config(config_path, DEFAULT_CONFIGS)
+        resolver = Resolver(listen_address, listen_port,
+                            config[CONFIG_SECTION]['downloaded_cti_path'])
         address, port = resolver.start()
         pid = os.getpid()
-        with open(SEEKER_PID_FILEPATH, 'w') as fout:
+        with open(pid_file, 'w') as fout:
             fout.write(f'{pid}\t{address}\t{port}\n')
         assert resolver.thread
         resolver.thread.join()
     except KeyboardInterrupt:
         LOGGER.info('caught SIGINT.')
     finally:
-        os.unlink(SEEKER_PID_FILEPATH)
+        if os.path.exists(pid_file):
+            os.unlink(pid_file)
 
 
 if __name__ == '__main__':
-    main(sys.argv[1], sys.argv[2])
+    if len(sys.argv) < 4:
+        raise Exception('Not enough arguments')
+    addr_ = sys.argv[1]
+    port_ = sys.argv[2]
+    app_dir_ = sys.argv[3]
+    config_path_ = sys.argv[4] if len(sys.argv) > 4 else None
+    main(addr_, int(port_), app_dir_, config_path_)

--- a/metemcyber/core/solver.py
+++ b/metemcyber/core/solver.py
@@ -28,6 +28,8 @@ from .bc.cti_operator import CTIOperator
 from .bc.eventlistener import BasicEventListener
 from .logger import get_logger
 
+SIGNATURE_HEADER = 'Metemcyber-Signature'
+
 LOGGER = get_logger(name='solver', file_prefix='core.bc')
 
 
@@ -159,7 +161,7 @@ class BaseSolver:
         data = json.dumps(data_obj)
         sign = self.account.sign_message(str(data))
         headers = {"Content-Type": "application/json",
-                   "MetemcyberSignature": sign}
+                   SIGNATURE_HEADER: sign}
         # httpリクエストを準備してPOST
         request = Request(url, data=data.encode('utf-8'), method="POST", headers=headers)
         with urlopen(request) as response:

--- a/metemcyber/core/solver.py
+++ b/metemcyber/core/solver.py
@@ -15,6 +15,7 @@
 #
 
 import json
+from configparser import ConfigParser
 from typing import Any, Callable, Dict, List, Optional
 from urllib.request import Request, urlopen
 
@@ -23,10 +24,11 @@ from eth_utils.exceptions import ValidationError
 from requests.exceptions import HTTPError
 from web3.datastructures import AttributeDict
 
-from .bc.account import Account
-from .bc.cti_operator import CTIOperator
-from .bc.eventlistener import BasicEventListener
-from .logger import get_logger
+from metemcyber.core.bc.account import Account
+from metemcyber.core.bc.cti_operator import CTIOperator
+from metemcyber.core.bc.eventlistener import BasicEventListener
+from metemcyber.core.logger import get_logger
+from metemcyber.core.util import merge_config
 
 SIGNATURE_HEADER = 'Metemcyber-Signature'
 
@@ -63,11 +65,13 @@ class ChallengeListener(BasicEventListener):
 
 
 class BaseSolver:
-    def __init__(self, account: Account, operator_address: ChecksumAddress) -> None:
+    def __init__(self, account: Account, operator_address: ChecksumAddress,
+                 config_path: Optional[str] = None) -> None:
         LOGGER.info('initializing solver %s for %s', self, operator_address)
         self.account: Account = account
         self.operator_address: ChecksumAddress = operator_address
         self.listener: Optional[ChallengeListener] = None
+        self.config: ConfigParser = merge_config(config_path, {})
 
     def destroy(self):
         LOGGER.info('destructing solver %s for %s', self, self.operator_address)

--- a/metemcyber/core/util.py
+++ b/metemcyber/core/util.py
@@ -16,7 +16,7 @@
 
 from configparser import ConfigParser
 from random import randint
-from typing import Any, Dict, Optional
+from typing import Dict, Optional
 
 LOCAL_PORT_RANGE_FILE = '/proc/sys/net/ipv4/ip_local_port_range'
 LOCAL_PORT_MIN = 0
@@ -38,7 +38,7 @@ def get_random_local_port() -> int:
     return randint(LOCAL_PORT_MIN, LOCAL_PORT_MAX)
 
 
-def merge_config(file_path: Optional[str], defaults: Dict[str, Dict[str, Any]],
+def merge_config(file_path: Optional[str], defaults: Dict[str, Dict[str, str]],
                  base_config: Optional[ConfigParser] = None) -> ConfigParser:
     config = base_config if base_config else ConfigParser()
     if file_path:

--- a/metemcyber/core/util.py
+++ b/metemcyber/core/util.py
@@ -14,7 +14,9 @@
 #    limitations under the License.
 #
 
+from configparser import ConfigParser
 from random import randint
+from typing import Any, Dict, Optional
 
 LOCAL_PORT_RANGE_FILE = '/proc/sys/net/ipv4/ip_local_port_range'
 LOCAL_PORT_MIN = 0
@@ -34,3 +36,18 @@ def get_random_local_port() -> int:
             LOCAL_PORT_MIN = 50000
             LOCAL_PORT_MAX = 59999
     return randint(LOCAL_PORT_MIN, LOCAL_PORT_MAX)
+
+
+def merge_config(file_path: Optional[str], defaults: Dict[str, Dict[str, Any]],
+                 base_config: Optional[ConfigParser] = None) -> ConfigParser:
+    config = base_config if base_config else ConfigParser()
+    if file_path:
+        if file_path not in config.read(file_path):
+            raise Exception(f'Load config failed: {file_path}')
+    for sect, sect_item in defaults.items():
+        if not config.has_section(sect):
+            config.add_section(sect)
+        for key, val in sect_item.items():
+            if not config[sect].get(key):
+                config.set(sect, key, val)
+    return config

--- a/metemcyber/core/webhook.py
+++ b/metemcyber/core/webhook.py
@@ -78,8 +78,8 @@ class WebhookReceiver():
         Thread(target=self.callback, args=[headers, body], daemon=True).start()
         return 'ok'
 
-    @staticmethod
-    def resolve_request(headers: EnvironHeaders, body: str) -> None:
+    def resolve_request(self, headers: EnvironHeaders, body: str) -> None:
+        print(self)
         print(headers)
         print('--')
         print(body)

--- a/metemcyber/plugins/gcs_solver.py
+++ b/metemcyber/plugins/gcs_solver.py
@@ -46,6 +46,7 @@ class Solver(BaseSolver):
         try:
             url = self.config[CONFIG_SECTION]['functions_url']
             token = self.config[CONFIG_SECTION]['functions_token']
+            assert url and token
         except Exception as err:
             raise Exception('Not enough configuration to upload to GCS') from err
         self.uploader = Uploader(url, token)


### PR DESCRIPTION
seeker, solver の設定管理を調整しました。
- seeker は start 時に、solver は enable 時に `--config` オプションで設定ファイルを指定可能です。
- セクション名は競合しないはずで、無関係な設定値は無視しますので、metemctl.ini に設定・指定しても構いません。
- config が不完全な場合を個別にケアするのが面倒なので、システムデフォルト値を用意してマージするような仕組みにしてみました。（gcs solver での API キーのようにデフォルト値が用意できないケースもありますが）
- その他、幾つかの細かい調整を含みます。