### PR TITLE
fix metadata

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -17,18 +17,20 @@
 # See https://setuptools.readthedocs.io/en/latest/setuptools.html
 
 [metadata]
+license_file = LICENSE
 name = metemcyber
 version = attr: metemcyber.__version__
 author = NTT Communications Corporation
 author_email = metemcyber@ntt.com
-license = Apache-2
 description = Decentralized Cyber Threat Intelligence Kaizen Framework.
 long_description = file: README.md
 long_description_content_type = text/markdown
 keywords = cti, cyber, threat, intelligence, data pipelines, ethereum
 url = https://github.com/nttcom/metemcyber
 project_urls =
+    Source = https://github.com/nttcom/metemcyber/
     Bug Tracker = https://github.com/nttcom/metemcyber/issues
+    Documentation = http://metemcyber.readthedocs.org/
 classifiers =
     Development Status :: 3 - Alpha
     Intended Audience :: Developers
@@ -59,7 +61,7 @@ max-line-length = 100
 [isort]
 # known_first_party=
 # known_third_party=
-line_length=100
+line_length = 100
 
 [mypy]
 ignore-missing-imports = True


### PR DESCRIPTION
- twineを参考に、LICENSE表示を修正しました :pray:(https://github.com/pypa/twine)
- SourceとDocumentationの場所をパッケージに記載
- コードフォーマットの統一