### PR TITLE
refine around configs

### DIFF
--- a/metemcyber/core/plugin.py
+++ b/metemcyber/core/plugin.py
@@ -27,7 +27,7 @@ from .solver import BaseSolver
 
 LOGGER = get_logger(name='plugin', file_prefix='core')
 # the directory where plugins are placed
-PLUGINS_PATH = os.getenv('PLUGINS_PATH', './metemcyber/plugins')
+PLUGINS_PATH = os.getenv('PLUGINS_PATH', os.path.dirname(__file__) + '/../plugins')
 SOLVER_CLASSNAME = 'Solver'
 
 

--- a/metemcyber/plugins/gcs_solver.py
+++ b/metemcyber/plugins/gcs_solver.py
@@ -35,7 +35,7 @@ DEFAULT_CONFIGS = {
     CONFIG_SECTION: {
         'assets_path': 'workspace/dissemination',  # FIXME
         'functions_url': 'https://exchange.metemcyber.ntt.com',
-        'functions_token': '',
+        'functions_token': 'YOUR_TOKEN_TO_UPLOAD_GCS',
     }
 }
 
@@ -48,7 +48,8 @@ class Solver(BaseSolver):
         try:
             url = self.config[CONFIG_SECTION]['functions_url']
             token = self.config[CONFIG_SECTION]['functions_token']
-            assert url and token
+            assert url and token not in (
+                None, '', DEFAULT_CONFIGS[CONFIG_SECTION]['functions_token'])
         except Exception as err:
             raise Exception('Not enough configuration to upload to GCS') from err
         self.uploader = Uploader(url, token)


### PR DESCRIPTION
設定周りを整理しました。
- 設定参照時は直接 ctx.meta['config'] を参照せず、`_load_config(ctx)` してください。
- 最初期の設定ファイル生成ルーチン（テンプレートをコピーする方式）は、ひとまず無効化してあります。別途、マージ形式での設定配布手段を検討する必要がありそうです。
- _load_config 後はシステムデフォルトがマージされますので、キーエラーの類は（基本的には）発生しません。
- サブコマンド config show および config edit の内容も、システムデフォルトがマージされた内容になります。
- ただし --raw オプションを付けることで生データを扱うことも可能です。コメントアウトしたい（かつ残したい）場合は `config edit --raw` で可能です（今のところは）。
＃ おそらくですが、個別の set 系コマンドを実装するとコメントの類を消してしまうことになると思います。