### PR TITLE
Update kedro versiton to 0.17.2

### DIFF
--- a/requirements/tools.txt
+++ b/requirements/tools.txt
@@ -1,2 +1,2 @@
-kedro==0.17.0
+kedro==0.17.2
 kedro-viz==3.10.1


### PR DESCRIPTION
https://github.com/quantumblacklabs/kedro-starters/commit/3a7a04d526b4605a7605ccdc56bf532daebae48e

pipelineの登録方法を最新に合わせるため、kedroのバージョンを0.17.2に変更しました。