### PR TITLE
fix setup.cfg

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,3 @@
 include README.md
 include LICENSE.md
 include requirements.txt
-recursive-include metemcyber/cli *
-recursive-include metemcyber/core/bc/contracts_data *

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include README.md
 include LICENSE.md
 include requirements.txt
-recursive-include requirements *
+recursive-include metemcyber/cli *
+recursive-include metemcyber/core/bc/contracts_data *

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = [
+    "setuptools>=42",
+    "wheel"
+]
+build-backend = "setuptools.build_meta"

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -16,3 +16,4 @@ typer==0.3.2
 psutil
 cryptography
 eth-account==0.5.4
+PyYAML==5.4.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,6 +45,9 @@ python_requires = >=3.8
 packages = find:
 include_package_data = True
 
+[options.package_data]
+metemcyber = core/bc/contracts_data/*.combined.json*, cli/*
+
 [options.entry_points]
 console_scripts =
     metemctl = metemcyber.cli.cli:app

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,13 +42,8 @@ classifiers =
 
 [options]
 python_requires = >=3.8
-package_dir =
-    = metemcyber
 packages = find:
 include_package_data = True
-
-[options.packages.find]
-where = metemcyber
 
 [options.entry_points]
 console_scripts =
@@ -64,4 +59,4 @@ max-line-length = 100
 line_length = 100
 
 [mypy]
-ignore-missing-imports = True
+ignore_missing_imports = True


### PR DESCRIPTION
パッケージ設定のバグを修正しました。
これで`site-packages`配下の`metemcyber`フォルダが正しいディレクトリ構成になります。

パッケージをビルドするコマンド
`python -m build -n`

パッケージをインストールするコマンド
`pip install --force-reinstall metemcyber-*-none-any.whl`

パッケージをアンインストールするコマンド
`pip uninstall metemcyber`