### PR TITLE
enhance config to see workspace

### DIFF
--- a/metemcyber/cli/cli.py
+++ b/metemcyber/cli/cli.py
@@ -34,6 +34,7 @@ import yaml
 from eth_typing import ChecksumAddress
 from web3 import Web3
 
+from metemcyber.cli.constants import APP_DIR
 from metemcyber.core.bc.account import Account
 from metemcyber.core.bc.broker import Broker
 from metemcyber.core.bc.catalog import Catalog, TokenInfo
@@ -53,8 +54,6 @@ from metemcyber.core.util import config2str, merge_config
 from metemcyber.plugins.gcs_solver import DEFAULT_CONFIGS as DC_SOLV_GCS
 from metemcyber.plugins.standalone_solver import DEFAULT_CONFIGS as DC_SOLV_ALN
 
-APP_NAME = "metemcyber"
-APP_DIR = typer.get_app_dir(APP_NAME)
 CONFIG_FILE_NAME = "metemctl.ini"
 CONFIG_FILE_PATH = Path(APP_DIR) / CONFIG_FILE_NAME
 WORKSPACE_CONFIG_FILENAME = 'config.ini'

--- a/metemcyber/cli/constants.py
+++ b/metemcyber/cli/constants.py
@@ -1,0 +1,20 @@
+#
+#    Copyright 2021, NTT Communications Corp.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+import typer
+
+APP_NAME = "metemcyber"
+APP_DIR = typer.get_app_dir(APP_NAME)

--- a/metemcyber/core/seeker.py
+++ b/metemcyber/core/seeker.py
@@ -27,6 +27,7 @@ from eth_typing import ChecksumAddress
 from psutil import NoSuchProcess, Process
 from werkzeug.datastructures import EnvironHeaders
 
+from metemcyber.cli.cli import APP_DIR
 from metemcyber.core.bc.account import Account
 from metemcyber.core.bc.ether import Ether
 from metemcyber.core.bc.operator import Operator
@@ -41,7 +42,7 @@ LOGGER = get_logger(name='seeker', file_prefix='core')
 CONFIG_SECTION = 'seeker'
 DEFAULT_CONFIGS = {
     CONFIG_SECTION: {
-        'downloaded_cti_path': './download',
+        'downloaded_cti_path': f'{APP_DIR}/workspace/download',
         'listen_address': '127.0.0.1',
         'listen_port': '0',
         'ngrok': '0',

--- a/metemcyber/core/seeker.py
+++ b/metemcyber/core/seeker.py
@@ -27,7 +27,7 @@ from eth_typing import ChecksumAddress
 from psutil import NoSuchProcess, Process
 from werkzeug.datastructures import EnvironHeaders
 
-from metemcyber.cli.cli import APP_DIR
+from metemcyber.cli.constants import APP_DIR
 from metemcyber.core.bc.account import Account
 from metemcyber.core.bc.ether import Ether
 from metemcyber.core.bc.operator import Operator

--- a/metemcyber/plugins/gcs_solver.py
+++ b/metemcyber/plugins/gcs_solver.py
@@ -23,7 +23,7 @@ import requests
 from eth_typing import ChecksumAddress
 from web3 import Web3
 
-from metemcyber.cli.cli import APP_DIR
+from metemcyber.cli.constants import APP_DIR
 from metemcyber.core.bc.account import Account
 from metemcyber.core.logger import get_logger
 from metemcyber.core.solver import BaseSolver

--- a/metemcyber/plugins/gcs_solver.py
+++ b/metemcyber/plugins/gcs_solver.py
@@ -23,6 +23,7 @@ import requests
 from eth_typing import ChecksumAddress
 from web3 import Web3
 
+from metemcyber.cli.cli import APP_DIR
 from metemcyber.core.bc.account import Account
 from metemcyber.core.logger import get_logger
 from metemcyber.core.solver import BaseSolver
@@ -33,7 +34,7 @@ LOGGER = get_logger(name='gcs_solver', file_prefix='core')
 CONFIG_SECTION = 'gcs_solver'
 DEFAULT_CONFIGS = {
     CONFIG_SECTION: {
-        'assets_path': 'workspace/dissemination',  # FIXME
+        'assets_path': f'{APP_DIR}/workspace/upload',
         'functions_url': 'https://exchange.metemcyber.ntt.com',
         'functions_token': 'YOUR_TOKEN_TO_UPLOAD_GCS',
     }

--- a/metemcyber/plugins/standalone_solver.py
+++ b/metemcyber/plugins/standalone_solver.py
@@ -22,7 +22,7 @@ from typing import ClassVar, Optional
 from eth_typing import ChecksumAddress
 from web3 import Web3
 
-from metemcyber.cli.cli import APP_DIR
+from metemcyber.cli.constants import APP_DIR
 from metemcyber.core.bc.account import Account
 from metemcyber.core.logger import get_logger
 from metemcyber.core.solver import BaseSolver

--- a/metemcyber/plugins/standalone_solver.py
+++ b/metemcyber/plugins/standalone_solver.py
@@ -22,6 +22,7 @@ from typing import ClassVar, Optional
 from eth_typing import ChecksumAddress
 from web3 import Web3
 
+from metemcyber.cli.cli import APP_DIR
 from metemcyber.core.bc.account import Account
 from metemcyber.core.logger import get_logger
 from metemcyber.core.solver import BaseSolver
@@ -36,7 +37,7 @@ CONFIG_SECTION = 'standalone_solver'
 DEFAULT_CONFIGS = {
     CONFIG_SECTION: {
         'listen_address': 'localhost',
-        'contents_root': 'workspace/dissemination',  # FIXME
+        'contents_root': f'{APP_DIR}/workspace/upload',
     }
 }
 


### PR DESCRIPTION
config に workspace の概念を追加しました。
- システムデフォルト -> metemctl.ini -> config.ini in workspace の順にオーバーロード（右側優先）します。
- システムデフォルトがあるので metemctl.ini が無くても workspace/config.ini があれば問題ありません。
- edit 時は config.ini in workspace に書き込みます。（config edit --raw --general で metemctl.ini の直接編集も可能ですが、十分に理解した人でないと使えないと思います）
- workspace 設定が矛盾している場合はエラー終了します。