### PR TITLE
Topic/enhance publish

### DIFF
--- a/metemcyber/cli/cli.py
+++ b/metemcyber/cli/cli.py
@@ -1553,7 +1553,6 @@ def _publish(
     typer.echo(f'registered token({token_address}) onto catalog({catalog.address}).')
     catalog.publish_cti(account.eoa, cast(ChecksumAddress, token_address))
     typer.echo(f'Token({token_address}) was published on catalog({catalog.address}).')
-    catalog.sync_catalog(super_reload=True)
     _broker_serve(ctx, [catalog.address, token_address], serve_amount)
 
 

--- a/metemcyber/cli/cli.py
+++ b/metemcyber/cli/cli.py
@@ -1389,7 +1389,7 @@ def parse_misp_object(filepath: Path) -> Tuple[str, str]:
                     title = event['info']
         except json.JSONDecodeError as err:
             logger.exception(err)
-            typer.echo(f'An error occurred while parsing your misp object. {err}')
+            raise Exception(f'An error occurred while parsing your misp object. {err}') from err
     return uuid, title
 
 
@@ -1397,28 +1397,25 @@ def parse_misp_object(filepath: Path) -> Tuple[str, str]:
 def publish(
         ctx: typer.Context,
         misp_object: str,
-        catalog: Optional[int] = typer.Option(
-            1,
+        catalog: str = typer.Option(
+            '1',
             help='A CTI catalog id/address to use for dissemination'),
-    token_address: Optional[str] = typer.Option(
+        token_address: Optional[str] = typer.Option(
             None,
             help='A CTI token address to use for dissemination'),
-        operator_address: Optional[str] = typer.Option(
-            None,
-            help='A CTI operator address to use for dissemination'),
         uuid: Optional[str] = typer.Option(
             None,
             help='The uuid of misp object'),
         title: Optional[str] = typer.Option(
             None,
             help='The title of misp object'),
-        price: Optional[int] = typer.Option(
+        price: int = typer.Option(
             10,
             help='A price of CTI token (dissemination cost)'),
-        initial_amount: Optional[int] = typer.Option(
+        initial_amount: int = typer.Option(
             100,
             help='An initial supply amount of CTI tokens'),
-        serve_amount: Optional[int] = typer.Option(
+        serve_amount: int = typer.Option(
             99,
             help='An amount of CTI tokens to give CTI broker'),
 ):
@@ -1427,12 +1424,75 @@ def publish(
         misp_object,
         catalog,
         token_address,
-        operator_address,
         uuid,
         title,
         price,
         initial_amount,
         serve_amount)
+
+
+def _uuid_to_misp_upload_path(_ctx, uuid) -> Path:
+    return Path(f'{APP_DIR}/misp/upload/{str(UUID(uuid))}')
+
+
+def _fix_misp_object(ctx, misp_object, uuid, title) -> Tuple[str, str, Path]:
+    if misp_object:
+        misp_obj_filepath = Path(misp_object) if misp_object.startswith('/') else \
+            Path(os.getcwd()) / misp_object
+        typer.echo(f'loading {misp_obj_filepath}.')
+        loaded_uuid, loaded_title = parse_misp_object(misp_obj_filepath)
+    else:
+        misp_obj_filepath = None
+        loaded_uuid = loaded_title = ''
+
+    if uuid and loaded_uuid and uuid != loaded_uuid:
+        raise Exception(f'Contradicory uuid: {uuid}, {loaded_uuid}')
+    uuid = uuid if uuid else loaded_uuid
+    if not uuid:
+        raise Exception('Missing uuid')
+    uuid = str(UUID(uuid))
+
+    if title and loaded_title and title != loaded_title:
+        raise Exception(f'Contradictory title: {title}, {loaded_title}')
+    title = title if title else loaded_title
+    if not title:
+        raise Exception('Missing title')
+
+    upload_filepath = _uuid_to_misp_upload_path(ctx, uuid)
+    if upload_filepath == misp_obj_filepath:
+        typer.echo(f'MISP upload file already exists: {upload_filepath}')
+        try:
+            typer.confirm('overwrite and continue?', abort=True)
+        except Exception as err:
+            raise Exception('Interrupted') from err  # click.exceptions.Abort has no message
+    return uuid, title, upload_filepath
+
+
+def _fix_amounts(ctx, token_address, initial_amount, serve_amount
+                 ) -> Tuple[Optional[str], Optional[Callable[[], None]]]:
+    if initial_amount <= 0:
+        raise Exception(f'Invalid initial_amount: {initial_amount}')
+    if serve_amount < 0:
+        raise Exception(f'Invalid serve_amount: {serve_amount}')
+    if initial_amount < serve_amount:
+        raise Exception(
+            f'Invalid serve amount in excess of initial supply: {serve_amount} > {initial_amount}')
+    if token_address:
+        account = _load_account(ctx)
+        token = Token(account).get(token_address)
+        balance = token.balance_of(account.eoa)
+        diff = balance - initial_amount
+        if diff < 0:
+            return (
+                f'You only have {balance} tokens. {-diff} tokens will be minted.',
+                lambda: token.mint(-diff, account.eoa)
+            )
+        if diff > 0:
+            return (
+                f'You already have {balance} tokens. {diff} tokens will be burned.',
+                lambda: token.burn(diff, '')
+            )
+    return None, None
 
 
 @common_logging
@@ -1441,30 +1501,19 @@ def _publish(
         misp_object,
         catalog,
         token_address,
-        operator_address,
         uuid,
         title,
         price,
         initial_amount,
         serve_amount):
 
-    misp_obj_filepath = Path(os.getcwd()) / misp_object
-    typer.echo(misp_obj_filepath)
-    uuid, title = parse_misp_object(misp_obj_filepath)
-
-    if len(title) == 0:
-        raise Exception(f'Invalid(empty) title')
+    uuid, title, upload_filepath = _fix_misp_object(ctx, misp_object, uuid, title)
+    notice_token, fix_token = _fix_amounts(ctx, token_address, initial_amount, serve_amount)
     if price < 0:
         raise Exception(f'Invalid price: {price}')
-    if initial_amount < serve_amount:
-        raise Exception(
-            f'Invalid serve amount in excess of initial supply: {serve_amount} > {initial_amount}')
-    if not operator_address:
-        config = _load_config(ctx)
-        # A Key Error exception is trapped by @common_logging
-        operator_address = config['operator']['address']
-    if token_address:
-        initial_amount = 0
+
+    operator_address = _load_operator(ctx).address
+    flx_catalog = FlexibleIndexCatalog(ctx, catalog)
 
     typer.echo(f'{"":=<64}')
     typer.echo(f'{title}')
@@ -1473,33 +1522,39 @@ def _publish(
     typer.echo(f' - Price: {price}')
     if token_address:
         typer.echo(f' - Charge: {serve_amount} (Token: {token_address})')
+        if notice_token:
+            typer.echo(f'           <!> {notice_token} <!>')
     else:
         typer.echo(f' - Sales Quantity: {serve_amount} (Initial Supply: {initial_amount})')
     typer.echo(f' - Exchanger: {operator_address}')
-    typer.echo(f' - Catalog ID/Address: {catalog}')
+    typer.echo(f' - Catalog: {flx_catalog.index}: {flx_catalog.address}')
     typer.echo(f'{"":=<64}')
 
-    yes = typer.confirm('Are you sure you want to publish it?', abort=True)
+    try:
+        typer.confirm('Are you sure you want to publish it?', abort=True)
+    except Exception as err:
+        raise Exception('Interrupted') from err  # click.exceptions.Abort has no message
 
-    if yes:
-        if not token_address:
-            token_address = _token_create(ctx, initial_amount)
+    if not token_address:
+        token_address = _token_create(ctx, initial_amount)
+    elif fix_token:
+        fix_token()  # mint or burn
 
-        account = _load_account(ctx)
-        catalog = Catalog(account).get(FlexibleIndexCatalog(ctx, catalog).address)
-        catalog.register_cti(
-            cast(
-                ChecksumAddress,
-                token_address),
-            uuid,
-            title,
-            price,
-            operator_address)
-        typer.echo(f'registered token({token_address}) onto catalog({catalog.address}).')
-        catalog.publish_cti(account.eoa, cast(ChecksumAddress, token_address))
-        typer.echo(f'Token({token_address}) was published on catalog({catalog.address}).')
-        catalog.sync_catalog(super_reload=True)
-        _broker_serve(ctx, [catalog.address, token_address], serve_amount)
+    account = _load_account(ctx)
+    catalog = Catalog(account).get(flx_catalog.address)
+    catalog.register_cti(
+        cast(
+            ChecksumAddress,
+            token_address),
+        uuid,
+        title,
+        price,
+        operator_address)
+    typer.echo(f'registered token({token_address}) onto catalog({catalog.address}).')
+    catalog.publish_cti(account.eoa, cast(ChecksumAddress, token_address))
+    typer.echo(f'Token({token_address}) was published on catalog({catalog.address}).')
+    catalog.sync_catalog(super_reload=True)
+    _broker_serve(ctx, [catalog.address, token_address], serve_amount)
 
 
 @account_app.command("show", help="Show the current account information.")

--- a/metemcyber/core/bc/catalog.py
+++ b/metemcyber/core/bc/catalog.py
@@ -68,7 +68,7 @@ class Catalog():
 
     def get(self, address: ChecksumAddress) -> Catalog:
         self.address = address
-        self.sync_catalog()
+        self._sync_catalog()
         return self
 
     def get_by_id(self, catalog_id: int) -> Catalog:
@@ -93,10 +93,10 @@ class Catalog():
                     in Catalog.__addressed_catalogs.values()] + [0]
                    ) + 1
 
-    def sync_catalog(self, super_reload: bool = False) -> None:
+    def _sync_catalog(self) -> None:
         assert self.address
         cinfo = self._catalogs_by_address.get(self.address)
-        if not cinfo or super_reload:
+        if not cinfo:
             cinfo = CatalogInfo(self.address, self.catalog_id, None, None, {})
             Catalog.__addressed_catalogs[self.address] = cinfo
             cti_catalog = CTICatalog(self.account).get(self.address)
@@ -140,11 +140,13 @@ class Catalog():
         assert self.address
         cti_catalog = CTICatalog(self.account).get(self.address)
         cti_catalog.register_cti(token, uuid, title, price, operator)
+        self.uncache()
 
     def publish_cti(self, producer: ChecksumAddress, token: ChecksumAddress) -> None:
         assert self.address
         cti_catalog = CTICatalog(self.account).get(self.address)
         cti_catalog.publish_cti(producer, token)
+        self.uncache()
 
     def modify_cti(self, token: ChecksumAddress, uuid: UUID, title: str, price: int) -> None:
         if price < 0:
@@ -152,8 +154,10 @@ class Catalog():
         assert self.address
         cti_catalog = CTICatalog(self.account).get(self.address)
         cti_catalog.modify_cti(token, uuid, title, price, '')
+        self.uncache()
 
     def unregister_cti(self, token: ChecksumAddress) -> None:
         assert self.address
         cti_catalog = CTICatalog(self.account).get(self.address)
         cti_catalog.unregister_cti(token)
+        self.uncache()

--- a/metemcyber/plugins/gcs_solver.py
+++ b/metemcyber/plugins/gcs_solver.py
@@ -39,6 +39,7 @@ DEFAULT_CONFIGS = {
         'functions_token': 'YOUR_TOKEN_TO_UPLOAD_GCS',
     }
 }
+# Note: assets_path should be same with "{general.workspace}/upload".
 
 
 class Solver(BaseSolver):

--- a/metemcyber/plugins/standalone_solver.py
+++ b/metemcyber/plugins/standalone_solver.py
@@ -37,19 +37,20 @@ CONFIG_SECTION = 'standalone_solver'
 DEFAULT_CONFIGS = {
     CONFIG_SECTION: {
         'listen_address': 'localhost',
-        'contents_root': f'{APP_DIR}/workspace/upload',
+        'assets_path': f'{APP_DIR}/workspace/upload',
     }
 }
+# Note: assets_path should be same with "{general.workspace}/upload".
 
 
 class SimpleHandler(SimpleHTTPRequestHandler):
-    contents_root: ClassVar[str] = ''  # Oops, is there smart way to set contents_root?
+    assets_path: ClassVar[str] = ''  # Oops, is there smart way to set contents_root?
 
     def __init__(self, *args, **kwargs):
-        assert SimpleHandler.contents_root
+        assert SimpleHandler.assets_path
         self.logpref = 'LocalHttpServer'
         SimpleHTTPRequestHandler.__init__(
-            self, *args, directory=SimpleHandler.contents_root, **kwargs)
+            self, *args, directory=SimpleHandler.assets_path, **kwargs)
 
     def do_GET(self):
         SimpleHTTPRequestHandler.do_GET(self)
@@ -68,7 +69,7 @@ class LocalHttpServer():
         self.server = None
         self.addr = addr
         self.port = 0
-        self.contents_root = root
+        self.assets_path = root
         self.handler = SimpleHandler
 
     def start(self):
@@ -78,7 +79,7 @@ class LocalHttpServer():
         self.thread.start()
 
     def run(self):
-        SimpleHandler.contents_root = self.contents_root
+        SimpleHandler.assets_path = self.assets_path
         for _count in range(GET_RANDOM_RETRY_MAX):
             try:
                 self.port = get_random_local_port()
@@ -115,7 +116,7 @@ class Solver(BaseSolver):
         self.fileserver = LocalHttpServer(
             self.account.eoa,
             self.config[CONFIG_SECTION]['listen_address'],
-            self.config[CONFIG_SECTION]['contents_root'])
+            self.config[CONFIG_SECTION]['assets_path'])
         self.fileserver.start()
 
     def destroy(self):


### PR DESCRIPTION
publish コマンドの機能を強化しました。
- MISP オブジェクトと同時に title あるいは uuid を引数してした場合、引数を優先します。
- MISP オブジェクト（必要なら title, uuid を調整したもの）を misp/upload に生成します。既存の場合は上書き確認します。
- workspace/upload 配下に上記 MISP オブジェクトのシンボリックリンクを生成します。これは solver が使用します。
- MISP オブジェクトのファイル名は UUID、シンボリックリンクのファイル名は TokenAddress.json です。
- standalone_solver の設定パラメータ contents_root を、gcs_solver と同じ assets_path に変更しました。この設定は上記のシンボリックリンクが生成される workspace/upload を指す必要があります。
- 引数で既存トークンを指定した場合、initial_amount, serve_amount の値に適合するように（必要であれば）mint あるいは burn します。この内容は確認メッセージに表示します。

ついでに幾つか微調整を。
- solver start に enable オプションを追加しました。start に続けて enable（引数なし）を実行するのと等価です。
- catalog の sync_catalog(super_reload=true) を廃止しました。参照する時に reload するのでなく、更新処理を行った時点で uncache するのが正しい使い方です（uncache 処理が漏れていたので修正しています）。