### PR TITLE
Topic/open app dir dry run

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,13 +90,16 @@ metemctl ix buy $TOKEN_INDEX_OR_ADDRESS
 ```
 
 > ⚠️ **You need an account to use [ngrok](https://dashboard.ngrok.com/).** [Setup a local ngrok environment](https://dashboard.ngrok.com/get-started/setup).
->
->Open the application directory and **put the ngrok executable file there**:
->
+>Download [ngrok](https://dashboard.ngrok.com/) and extract it.
+>Open the application directory to **put the ngrok executable file there**:
 >```
 >metemctl open-app-dir
 >```
->Make sure the ngrok *authtoken* exists after [setup](https://dashboard.ngrok.com/get-started/setup):
+>```
+>$ ls "$(metemctl open-app-dir --dry-run)"
+>external-links.json             metemctl.ini                    ngrok                           ...
+>```
+>**Ngrok need to connect your ngrok account.** Make sure the ngrok *authtoken* exists after [ngrok setup](https://dashboard.ngrok.com/get-started/setup):
 >```
 >cat ~/.ngrok2/ngrok.yml
 >```

--- a/metemcyber/cli/cli.py
+++ b/metemcyber/cli/cli.py
@@ -1900,10 +1900,16 @@ def issue():
     typer.launch('https://github.com/nttcom/metemcyber/issues')
 
 
-@app.command(help="Access the Application Directoy of Metemcyber")
-def open_app_dir():
-    typer.echo(f"Open {APP_DIR}")
-    typer.launch(APP_DIR)
+@app.command(help="Access the application directoy of Metemcyber")
+def open_app_dir(
+    dry_run: bool = typer.Option(
+        False,
+        help='Output only the application directory path.')):
+    if dry_run:
+        typer.echo(f"{APP_DIR}")
+    else:
+        typer.echo(f"Open \'{APP_DIR}\'")
+        typer.launch(APP_DIR)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`metemctl open-app-dir`にドライランを追加することで、チュートリアルの手順を分かりやすくしました。
`metemctl open-app-dir --dry-run` でAPP_DIRのパスだけを表示します。