### PR TITLE
Topic/monitor option for ix use

### DIFF
--- a/src/metemcyber/cli/cli.py
+++ b/src/metemcyber/cli/cli.py
@@ -1197,7 +1197,7 @@ def _ix_use(ctx, token, seeker, ngrok, monitor):
     assert operator.address
     data = seeker if seeker else (NgrokMgr(APP_DIR).public_url or '') if ngrok else ''
     if not data:
-        raise Exception('Seeker url is not specified')
+        raise Exception('Seeker url is not specified (or ngrok is not running)')
     Token(account).get(flx.address).send(operator.address, amount=1, data=data)
     typer.echo(f'Started challenge with token({flx.address}).')
     if monitor:

--- a/src/metemcyber/cli/cli.py
+++ b/src/metemcyber/cli/cli.py
@@ -1019,7 +1019,7 @@ def solver_status(ctx: typer.Context) -> bool:
             typer.echo(f'Solver running with operator you configured({operator.address}).')
             return True
         typer.echo('[WARNING] '
-                    f'Solver running with another operator({solver.operator_address}).')
+                   f'Solver running with another operator({solver.operator_address}).')
     except MCSError as err:
         if err.code == MCSErrno.ENOENT:
             typer.echo('Solver running without your operator.')
@@ -1658,6 +1658,7 @@ def _build_query():
 
     return qname, query
 
+
 def _store_pretty_json(results, json_dumpdir):
     # store json file
     indent = 2
@@ -1693,7 +1694,6 @@ def misp_fetch(ctx: typer.Context):
     results = result if isinstance(result, list) else [result]
 
     _store_pretty_json(results, json_dumpdir)
-
 
 
 @misp_app.command("event", help="Show exported MISP events")

--- a/src/metemcyber/cli/cli.py
+++ b/src/metemcyber/cli/cli.py
@@ -16,6 +16,7 @@
 
 #pylint: disable=too-many-lines
 
+import errno
 import hashlib
 import json
 import os
@@ -59,6 +60,7 @@ from metemcyber.core.multi_solver import MCSClient, MCSErrno, MCSError
 from metemcyber.core.ngrok import DEFAULT_CONFIGS as DC_NGROK
 from metemcyber.core.ngrok import NgrokMgr
 from metemcyber.core.seeker import DEFAULT_CONFIGS as DC_SEEKER
+from metemcyber.core.seeker import TTY_FILEPATH as TTYLINK4SEEKER
 from metemcyber.core.seeker import Seeker
 from metemcyber.core.util import config2str, merge_config
 from metemcyber.plugins.gcs_solver import DEFAULT_CONFIGS as DC_SOLV_GCS
@@ -1181,12 +1183,14 @@ def ix_use(ctx: typer.Context, token: str,
                '', help='Globally accessible url which seeker is listening. '
                         'This option overwrites --ngrok.'),
            ngrok: bool = typer.Option(
-               True, help='Use ngrok public url bound up with seeker if launched.')):
-    _ix_use(ctx, token, seeker, ngrok)
+               True, help='Use ngrok public url bound up with seeker if launched.'),
+           monitor: bool = typer.Option(
+               True, help='Print messages from Seeker on current terminal.')):
+    _ix_use(ctx, token, seeker, ngrok, monitor)
 
 
 @common_logging
-def _ix_use(ctx, token, seeker, ngrok):
+def _ix_use(ctx, token, seeker, ngrok, monitor):
     flx = FlexibleIndexToken(ctx, token)
     account = _load_account(ctx)
     operator = _load_operator(ctx)
@@ -1196,6 +1200,32 @@ def _ix_use(ctx, token, seeker, ngrok):
         raise Exception('Seeker url is not specified')
     Token(account).get(flx.address).send(operator.address, amount=1, data=data)
     typer.echo(f'Started challenge with token({flx.address}).')
+    if monitor:
+        _monitor_seeker_message()
+
+
+def _monitor_seeker_message():
+    try:
+        tty = subprocess.run(['tty'], check=True, capture_output=True, text=True).stdout.strip()
+        if not os.path.exists(tty):
+            raise FileNotFoundError(errno.ENOENT, os.strerror(errno.ENOENT), tty)
+    except Exception as err:
+        typer.echo(f'cannot get tty: {err}')
+        typer.echo('give up monitoring seeker message. '
+                   'try "metemctl ix show [--done]" to check task status.')
+        return
+    try:
+        typer.echo('>> Start monitoring seeker message. type CTRL-C to abort.')
+        if os.path.exists(TTYLINK4SEEKER):
+            typer.echo('[CAUTION] TTY used by another monitoring process is overwritten.')
+            os.unlink(TTYLINK4SEEKER)  # force overwrite
+        os.symlink(tty, TTYLINK4SEEKER)
+        while input():
+            pass
+    except KeyboardInterrupt:
+        pass
+    finally:
+        os.unlink(TTYLINK4SEEKER)
 
 
 def _is_correct_sha256(filename, sha256):

--- a/src/metemcyber/core/bc/util.py
+++ b/src/metemcyber/core/bc/util.py
@@ -15,6 +15,7 @@
 #
 
 import json
+import os
 from getpass import getpass
 from typing import Callable, Tuple, cast
 
@@ -53,7 +54,8 @@ def decode_keyfile(filename: str,
 
 
 def deploy_erc1820(eoa: ChecksumAddress, web3: Web3) -> None:
-    erc1820_raw_tx_filepath = 'metemcyber/core/bc/erc1820.tx.raw'
+    src_dir = os.path.dirname(os.path.abspath(__file__))
+    erc1820_raw_tx_filepath = f'{src_dir}/erc1820.tx.raw'
     deployer_address = '0xa990077c3205cbDf861e17Fa532eeB069cE9fF96'
     contract_address = '0x1820a4B7618BdE71Dce8cdc73aAB6C95905faD24'
     code = web3.eth.getCode(contract_address)


### PR DESCRIPTION
ix use に --monitor オプション（デフォルト有効）を追加しました。
- コマンド実行した tty のシンボリックリンクを生成し、seeker 側は該当リンクが存在する場合はメッセージを投入します。
- tty の取得は tty コマンドに依存しています（他の手段は発見できず）。tty コマンドが無い（もしくは失敗）場合はその旨のメッセージを表示します。

複数の端末で monitor した場合（モニタ状態のまま別端末で ix use）、シンボリックリンクを上書きするので古い端末側にはメッセージが出力されません。この状態には問題が１つあって、古い側の端末でモニタを止めた際に TTY シンボリックリンクを削除してしまい、新しい側のモニタまで無効化してしまいます。頑張ればマシな状態にはできると思いますが、コストに見合わないと思うので放置してます。