### PR TITLE
Topic/enhance commands

### DIFF
--- a/src/metemcyber/cli/cli.py
+++ b/src/metemcyber/cli/cli.py
@@ -1372,7 +1372,7 @@ def _get_challenges(ctx: typer.Context
     limit_atonce = 16
     offset = 0
     while True:
-        tmp = operator.history(ADDRESS0, account.eoa, limit_atonce, offset)
+        tmp = operator.history(ADDRESS0, ADDRESS0, limit_atonce, offset)
         raw_tasks.extend(tmp)
         if len(tmp) < limit_atonce:
             break


### PR DESCRIPTION
metemctl コマンドの追加・調整を行いました。
- ix show --no-mine-only が正しく動作しない不具合を修正しました。
- ix show に --verbose オプション（デフォルト無効）を追加しました。Seeker, Solver を表示します。
- contract broker にサブコマンド takeback を追加しました。ブローカーに委託したトークンを引き取ります。（takeback-token の予定でしたが serve と合わせました）