### PR TITLE
Topic/support bulk buy

### DIFF
--- a/src/metemcyber/cli/cli.py
+++ b/src/metemcyber/cli/cli.py
@@ -832,7 +832,7 @@ def broker_serve(ctx: typer.Context, catalog_and_token: str, amount: int):
 def _broker_serve(ctx, catalog_and_token, amount):
     if amount <= 0:
         raise Exception(f'Invalid amount: {amount}')
-    if len(catalog_and_token) > 2:
+    if isinstance(catalog_and_token, list) and len(catalog_and_token) > 2:
         raise Exception('Redundant arguments for CATALOG_AND_TOKEN')
     flx_token = FlexibleIndexToken(ctx, catalog_and_token)
     if not flx_token.catalog:
@@ -859,7 +859,7 @@ def broker_takeback(ctx: typer.Context, catalog_and_token: str, amount: int):
 def _broker_takeback(ctx, catalog_and_token, amount):
     if amount <= 0:
         raise Exception(f'Invalid amount: {amount}')
-    if len(catalog_and_token) > 2:
+    if isinstance(catalog_and_token, list) and len(catalog_and_token) > 2:
         raise Exception('Redundant arguments for CATALOG_AND_TOKEN')
     flx_token = FlexibleIndexToken(ctx, catalog_and_token)
     if not flx_token.catalog:

--- a/src/metemcyber/core/bc/broker.py
+++ b/src/metemcyber/core/bc/broker.py
@@ -20,13 +20,12 @@ from typing import Dict, List, Optional
 
 from eth_typing import ChecksumAddress
 
-from .account import Account
-from .catalog import Catalog
-from .cti_broker import CTIBroker
-from .cti_token import CTIToken
-from .token import Token
-
-PTS_RATE: int = 10**18  # FIXME: should import from somewhere
+from metemcyber.core.bc.account import Account
+from metemcyber.core.bc.catalog import Catalog
+from metemcyber.core.bc.cti_broker import CTIBroker
+from metemcyber.core.bc.cti_token import CTIToken
+from metemcyber.core.bc.token import Token
+from metemcyber.core.constants import PTS_RATE
 
 
 class Broker():

--- a/src/metemcyber/core/constants.py
+++ b/src/metemcyber/core/constants.py
@@ -1,0 +1,17 @@
+#
+#    Copyright 2021, NTT Communications Corp.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+PTS_RATE: int = 10**18  # 1 PTS == 1 ETHER


### PR DESCRIPTION
カタログに含まれるトークン一式を購入するコマンド ix bulk-buy を実装しました。
- 既に持っているトークンであっても購入する場合はオプション --duplicated （デフォルト無効）を指定します。
- soldout だった場合、その旨を表示します。
- ETHER 不足で購入できなかった場合、当該トークンの購入は failed operation になりますが、bulk-buy の処理は継続します。
- 400 Bad Request だと ETHER 不足だと分らないので事前チェックするようにしました。ただし、ガス代が払えないケースはチェックできないので Bad Request になります。orz
- price チェックに必要な PTS_RATE の定義を broker.py から metemcyber.core.constants.py に移設しました。cli.py もここから import します。
