### PR TITLE
add transaction monitor

### DIFF
--- a/src/metemcyber/core/bc/monitor/slack_notifier.py
+++ b/src/metemcyber/core/bc/monitor/slack_notifier.py
@@ -1,0 +1,216 @@
+#
+#    Copyright 2021, NTT Communications Corp.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+import argparse
+import json
+import sys
+from typing import ClassVar, List, Tuple
+
+import requests
+
+import metemcyber.core.bc.monitor.tx_counter as tx_counter
+
+
+class SectionGenerator:
+    def summary_to_sections(self, summary: dict, **_kwargs) -> List[dict]:
+        return [{
+            'fallback': str(self),
+            'title': 'abstract generator',
+            'text': str(summary),
+        }]
+
+
+class Waixu(SectionGenerator):
+    colormap: ClassVar[List[str]] = [
+        '#CC0000', '#CC2200', '#CC4400', '#CC6600', '#CC8800', '#CC9900',
+        '#CCAA00', '#CCBB00', '#CCCC00', '#99CC00', '#00CC00', '#00CCCC',
+    ]
+
+    @staticmethod
+    def _calc_waicu(summary: dict) -> Tuple[int, str]:
+        if not summary.get('waicu'):
+            sold = []
+            num_sold = waicu = 0
+        else:
+            sold = sorted(
+                [(catalog,
+                  sum(val['tokens'].values()),
+                  len(val['buyers']),
+                  sorted(list(val['tokens'].items()), key=lambda x:x[1], reverse=True)
+                  )
+                 for catalog, val in summary['waicu'].items() if catalog != 'total'
+                 ],
+                reverse=True)
+            total = summary['waicu']['total']
+            waicu = len(total['buyers'].keys())
+            num_sold = sum(total['tokens'].values())
+
+        text = ''
+        if len(sold) > 0:
+            text = (f'*{num_sold} token{"s" if num_sold > 1 else ""} sold' +
+                    f' on {len(sold)} catalog{"s" if len(sold) > 1 else ""}' +
+                    f' by {waicu} buyer{"s" if waicu > 1 else ""}' +
+                    '*\n')
+            for catalog, num_sold, num_buyers, tokens in sold:
+                text += f'\tCatalog: `{catalog}`\n'
+                text += f'\t\tsold tokens (total: {num_sold}, buyer: {num_buyers})\n'
+                for token, num in tokens:
+                    text += f'\t\t\t{num} : {token}\n'
+
+        return waicu, text
+
+    @staticmethod
+    def _calc_waipu(summary: dict) -> Tuple[int, str]:
+        if not summary.get('waipu'):
+            pubed = []
+            waipu = num_pubed = num_unreg = 0
+        else:
+            pubed = sorted(
+                [(catalog,
+                  sum(val.get('publish', {'0': 0}).values()),
+                  len(val.get('publish', {'0': 0})),
+                  sum(val.get('unregister', {'0': 0}).values())
+                  )
+                 for catalog, val in summary['waipu'].items() if catalog != 'total'
+                 ],
+                reverse=True)
+            total = summary['waipu']['total']
+            waipu = len(total.get('publish', {}).keys())
+            num_pubed = sum(total.get('publish', {}).values())
+            num_unreg = sum(total.get('unregister', {}).values())
+
+        text = ''
+        if len(pubed) > 0:
+            text = (f'*{num_pubed} token{"s" if num_pubed > 1 else ""} published' +
+                    (f' (and unpublished {num_unreg})' if num_unreg > 0 else '') +
+                    f' on {len(pubed)} catalog{"s" if len(pubed) > 1 else ""}' +
+                    '*\n')
+            for catalog, n_pubed, n_puber, n_unreg, in pubed:
+                text += f'\tcatalog: `{catalog}`\n'
+                text += f'\t\tpublished: {n_pubed}, '
+                text += f'unpublish: {n_unreg}, ' if n_unreg > 0 else ''
+                text += f'publisher: {n_puber}\n'
+
+        return waipu, text
+
+    def summary_to_sections(self, summary: dict, **_kwargs) -> List[dict]:
+        waicu, waicu_text = self._calc_waicu(summary)
+        waipu, waipu_text = self._calc_waipu(summary)
+
+        title = f'WAICU={waicu}, WAIPU={waipu}'
+        text = waicu_text + waipu_text
+        score = min(int((waicu + waipu) / 2), len(Waixu.colormap) - 1)
+        color = Waixu.colormap[score]
+
+        return [{
+            'fallback': title,
+            'color': color,
+            'title': title,
+            'text': text,
+        }]
+
+
+class SlackNotifier:
+    conf: dict
+    sections: List[dict]
+    testmode: bool
+
+    def __new__(cls, *_args, **_kwargs):
+        if not hasattr(cls, '_instance'):
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __init__(self, config_filepath: str, testmode: bool = False):
+        if hasattr(self, 'conf') and self.conf:
+            return
+        with open(config_filepath, 'r') as fin:
+            self.conf = json.load(fin).get('slack_notifier', {})
+        for key in {'webhook', 'channel', 'appname'}:
+            if key not in self.conf.keys():
+                raise Exception(f'ConfigError: Missing {key}')
+        self.sections = []
+        self.testmode = testmode
+
+    def add_sections(self, sections):
+        if sections:
+            self.sections.extend(sections)
+
+    def send_query(self):
+        if not self.sections:
+            print('nothing to send. skip sending query.')
+            return
+
+        headers = {
+            'Content-type': 'application/json',
+        }
+        payload = {
+            'channel': self.conf['channel'],
+            'username': self.conf['appname'],
+            'attachments': self.sections,
+        }
+        if self.testmode:
+            print('__TestMode__')
+            print(json.dumps(payload, indent=2, ensure_ascii=False))
+            return
+
+        print(f'sending query to: {self.conf["webhook"]}', file=sys.stderr)
+        response = requests.post(
+            self.conf['webhook'],
+            headers=headers,
+            data=json.dumps(payload, ensure_ascii=False).encode('utf-8'))
+        print(response.text)
+
+
+def main(args):
+    notifier = SlackNotifier(args.config, testmode=args.testmode)
+    for cname in args.classes:
+        generator_class = (Waixu if cname == 'Waixu' else
+                           SectionGenerator if cname == 'Simple' else
+                           None)
+        if not generator_class:
+            raise Exception(f'Invalid GeneratorName: {args.generator}')
+        counter_class = (tx_counter.Waixu if cname == 'Waixu' else
+                         tx_counter.TransactionCounter if cname == 'Simple' else
+                         None)
+        if not counter_class:
+            raise Exception(f'Invalid ClassName: {cname}')
+        generator = generator_class()
+        counter = counter_class(args.config)
+        summary = counter.summarize(days=args.days, hours=args.hours)
+        notifier.add_sections(
+            generator.summary_to_sections(summary, days=args.days, hours=args.hours))
+    notifier.send_query()
+
+
+OPTIONS: List[Tuple[str, str, dict]] = [
+    ('-c', '--config', dict(action='store', required=True)),
+    ('-d', '--days', dict(action='store', type=int, default=0, required=False)),
+    ('-H', '--hours', dict(action='store', type=int, default=0, required=False)),
+    ('-t', '--testmode', dict(action='store_true', required=False)),
+]
+
+ARGUMENTS: List[Tuple[str, dict]] = [
+    ('classes', dict(choices=['Waixu', 'Simple'], nargs='*')),
+]
+
+if __name__ == '__main__':
+    PARSER = argparse.ArgumentParser()
+    for sname, lname, opts in OPTIONS:
+        PARSER.add_argument(sname, lname, **opts)
+    for name, opts in ARGUMENTS:
+        PARSER.add_argument(name, **opts)
+    ARGS = PARSER.parse_args()
+    main(ARGS)

--- a/src/metemcyber/core/bc/monitor/tx_counter.py
+++ b/src/metemcyber/core/bc/monitor/tx_counter.py
@@ -1,0 +1,188 @@
+#
+#    Copyright 2021, NTT Communications Corp.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+import argparse
+import json
+from typing import Dict, List, Optional, Tuple, Union
+
+from eth_typing import ChecksumAddress
+
+import metemcyber.core.bc.monitor.tx_util as util
+from metemcyber.core.bc.monitor.tx_db import TransactionDB
+from metemcyber.core.bc.monitor.tx_metadata_manager import MetadataManager
+from metemcyber.core.logger import get_logger
+
+LOGGER = get_logger(name='counter', file_prefix='tx_monitor')
+
+
+class BasicTx:
+    blocknum: int
+    index: int
+    addr_from: ChecksumAddress
+    addr_to: Optional[ChecksumAddress]
+    deployed: Optional[ChecksumAddress]
+    function: Optional[str]
+    gas: int
+    gas_price: int
+    value: int
+    input_data: Optional[Union[dict, str]]
+    status: int
+    contract: str
+    method: str
+
+    def __init__(self, tx0: dict):
+        self.blocknum = tx0['blockNumber']
+        self.index = tx0['transactionIndex']
+        self.addr_from = tx0['from']
+        self.addr_to = tx0.get('to')
+        self.deployed = tx0.get('deployed_address')
+        self.function = tx0.get('function')
+        self.gas = tx0['gas']
+        self.gas_price = tx0['gasPrice']
+        self.value = tx0.get('value', 0)
+        self.input_data = tx0.get('input')
+        self.status = tx0['x_receipt_status']
+        if self.function:
+            try:
+                self.contract, self.method = self.function.split('.', 1)
+            except Exception:
+                self.contract = '(Unknown)'
+                self.method = self.function
+        else:
+            self.contract = '(Unknown)'
+            self.method = '(Send ETHER)' if self.value > 0 else '(Unknown)'
+
+
+class TransactionCounter:
+    conf: dict
+    dec_db: TransactionDB
+    meta: MetadataManager
+    codesize: Dict[ChecksumAddress, int]
+
+    def __init__(self, config_filepath: str):
+        with open(config_filepath, 'r') as fin:
+            self.conf = json.load(fin).get('counter', {})
+        self.dec_db = TransactionDB(None, self.conf['db_filepath_decoded'])
+        self.meta = MetadataManager(config_filepath, readonly=True)
+        self.dec_db.open(readonly=True)
+        self.codesize = self.dec_db.get('codesize') or {}
+
+    def fix_startblock(self) -> int:
+        tmp = int(self.conf.get('start_block', 1))
+        if tmp > 0:
+            return tmp
+        tmp += self.dec_db.latest
+        return tmp if tmp > 0 else 1
+
+    def get_blocks(self, days: int = 0, hours: int = 0) -> List[int]:
+        assert days >= 0 and hours >= 0
+        border = -1
+        hours += days * 24
+        if hours > 0:
+            latest = self.dec_db.latest
+            border = latest - (hours * 3600 / 2)  # mine a block every 2 seconds.
+        return self.dec_db.stored_blocks(minimum=border if border > 0 else None)
+
+    def tx_to_entry(self, tx0: dict) -> List[List[str]]:
+        if not tx0:
+            return []
+        btx = BasicTx(tx0)
+        ret = []
+        if btx.contract == '(Unknown)':
+            if btx.method == '(deploy)':
+                btx.contract = self.meta.get(btx.deployed).get('name', '(Unknown)')
+            elif btx.addr_to:
+                btx.contract = self.meta.get(btx.addr_to).get('name') or (
+                    'EOA' if self.codesize.get(btx.addr_to) == 0 else '(Unknown)')
+        if btx.addr_to:
+            ret.append(['receiver', btx.contract, btx.addr_to, btx.method, btx.addr_from])
+            ret.append(['receiver', btx.contract, btx.addr_to, btx.method, 'total'])
+        category = 'EOA' if self.codesize.get(btx.addr_from) == 0 else 'EOA?'
+        ret.append(['sender', category, btx.addr_from, f'{btx.contract}.{btx.method}'])
+        return ret
+
+    def summarize(self, days: int = 0, hours: int = 0, reverted: Optional[bool] = False) -> dict:
+        summary: dict = {}
+        for block in self.get_blocks(days=days, hours=hours):
+            for tx0 in self.dec_db.load(block, None):
+                if reverted not in {None, tx0.get('x_receipt_status') != 1}:
+                    continue
+                for entry in self.tx_to_entry(tx0):
+                    summary = util.safe_inc(summary, entry)
+        return summary
+
+    def run(self, *args, **kwargs):
+        summary = self.summarize(*args, **kwargs)
+        print(json.dumps(summary, indent=2, sort_keys=True, ensure_ascii=False))
+
+
+class Waixu(TransactionCounter):
+    def tx_to_entry(self, tx0: dict) -> List[List[str]]:
+        if not tx0:
+            return []
+        btx = BasicTx(tx0)
+        ret = []
+        if btx.function == 'CTIBroker.buyToken':
+            assert isinstance(btx.input_data, dict)
+            catalog = btx.input_data['catalogAddress']
+            token = btx.input_data['tokenAddress']
+            ret.append(['waicu', catalog, 'tokens', token])
+            ret.append(['waicu', 'total', 'tokens', token])
+            ret.append(['waicu', catalog, 'buyers', btx.addr_from])
+            ret.append(['waicu', 'total', 'buyers', btx.addr_from])
+        elif btx.function == 'CTICatalog.publishCti':
+            ret.append(['waipu', btx.addr_to, 'publish', btx.addr_from])
+            ret.append(['waipu', 'total', 'publish', btx.addr_from])
+        elif btx.function == 'CTICatalog.unregisterCti':
+            ret.append(['waipu', btx.addr_to, 'unregister', btx.addr_from])
+            ret.append(['waipu', 'total', 'unregister', btx.addr_from])
+        return ret
+
+
+def main(args):
+    for cname in args.classes:
+        counter_class = (Waixu if cname == 'Waixu' else
+                         TransactionCounter if cname == 'Simple' else
+                         None)
+        if not counter_class:
+            raise Exception('Invalid ClassName: {cname}')
+        counter = counter_class(args.config)
+        counter.run(days=args.days, hours=args.hours,
+                    reverted=(True if args.reverted == 'yes' else
+                              False if args.reverted == 'no' else
+                              None)
+                    )
+
+
+OPTIONS: List[Tuple[str, str, dict]] = [
+    ('-d', '--days', dict(action='store', type=int, default=0, required=False)),
+    ('-H', '--hours', dict(action='store', type=int, default=0, required=False)),
+    ('-r', '--reverted', dict(choices=['yes', 'no', 'both'], default='no', required=False)),
+    ('-c', '--config', dict(action='store', required=True)),
+]
+
+ARGUMENTS: List[Tuple[str, dict]] = [
+    ('classes', dict(choices=['Waixu', 'Simple'], nargs='*')),
+]
+
+if __name__ == '__main__':
+    PARSER = argparse.ArgumentParser()
+    for sname, lname, opts in OPTIONS:
+        PARSER.add_argument(sname, lname, **opts)
+    for name, opts in ARGUMENTS:
+        PARSER.add_argument(name, **opts)
+    ARGS = PARSER.parse_args()
+    main(ARGS)

--- a/src/metemcyber/core/bc/monitor/tx_counter.py
+++ b/src/metemcyber/core/bc/monitor/tx_counter.py
@@ -23,9 +23,6 @@ from eth_typing import ChecksumAddress
 import metemcyber.core.bc.monitor.tx_util as util
 from metemcyber.core.bc.monitor.tx_db import TransactionDB
 from metemcyber.core.bc.monitor.tx_metadata_manager import MetadataManager
-from metemcyber.core.logger import get_logger
-
-LOGGER = get_logger(name='counter', file_prefix='tx_monitor')
 
 
 class BasicTx:

--- a/src/metemcyber/core/bc/monitor/tx_db.py
+++ b/src/metemcyber/core/bc/monitor/tx_db.py
@@ -1,0 +1,197 @@
+#
+#    Copyright 2021, NTT Communications Corp.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+import atexit
+import os
+import shelve
+from shelve import DbfilenameShelf as Shelf
+from time import sleep
+from typing import Any, Callable, List, Optional
+
+from web3.exceptions import BlockNotFound
+
+
+class TransactionDB:
+    filepath: str
+    shelf: Optional[Shelf]
+    earliest: int
+
+    def __init__(self, endpoint: Optional[str], filepath: str):
+        self.filepath = filepath
+        self.shelf = None  # for keep-connection mode
+        if os.path.exists(filepath):
+            saved = self.get('endpoint')
+            if not saved:
+                raise Exception(f'Endpoint is not saved in this dbfile: {filepath}')
+            if endpoint and saved != endpoint:
+                raise Exception(f'Endpoint mismatch (Saved endpoint is {saved})')
+        else:
+            if not endpoint:
+                raise Exception('Missing endpoint')
+            self.open(readonly=False)
+            self.update('endpoint', endpoint)
+            self.close()
+        self.earliest = self._shelf_wrapper(True, self._load_earliest)
+
+    def open(self, readonly=False):
+        assert self.filepath
+        if self.shelf:
+            raise Exception('already opened')
+        flag = 'r' if readonly else 'cu'  # flag 'u' requires python3-gdbm
+        self.shelf = shelve.open(self.filepath, flag)
+        atexit.register(self.close)
+
+    def close(self, allow_redundant=False):
+        if self.shelf is None:
+            if allow_redundant:
+                return
+            raise Exception('not opened')
+        self.shelf.close()
+        self.shelf = None  # switch out from keep-alive mode
+        atexit.unregister(self.close)
+
+    def _shelf_wrapper(self, readonly: bool, callback: Callable, *args, **kwargs):
+        if self.shelf:
+            return callback(self.shelf, *args, **kwargs)
+        flag = 'r' if readonly else 'cu'
+        with shelve.open(self.filepath, flag) as shelf:
+            return callback(shelf, *args, **kwargs)
+
+    def stored_blocks(self, *args, **kwargs) -> List[int]:
+        return self._shelf_wrapper(True, self._stored_blocks, *args, **kwargs)
+
+    @staticmethod
+    def _stored_blocks(shelf: Shelf, minimum: Optional[int] = None, maximum: Optional[int] = None
+                       ) -> List[int]:
+        return sorted([int(key) for key in list(shelf.keys())
+                       if key.isdecimal() and
+                          (minimum is None or int(key) >= minimum) and
+                          (maximum is None or int(key) <= maximum)])
+
+    def get(self, *args, **kwargs):
+        return self._shelf_wrapper(True, self._get, *args, **kwargs)
+
+    @staticmethod
+    def _get(shelf: Shelf, key: str):
+        return shelf.get(key)
+
+    @property
+    def latest(self) -> int:
+        return self._shelf_wrapper(True, self._load_latest)
+
+    def update(self, *args, **kwargs):
+        self._shelf_wrapper(False, self._update, *args, **kwargs)
+
+    @staticmethod
+    def _update(shelf: Shelf, key: str, value: Any):
+        shelf[key] = value
+
+    def update_latest(self, *args, **kwargs):
+        self._shelf_wrapper(False, self._update_latest, *args, **kwargs)
+
+    @staticmethod
+    def _update_latest(shelf: Shelf, latest: int, allow_shrink: bool = False):
+        if 'latest' not in shelf.keys():
+            shelf['latest'] = latest
+            return
+        if shelf['latest'] == latest:
+            return
+        if shelf['latest'] > latest and not allow_shrink:
+            return
+        shelf['latest'] = latest
+
+    @staticmethod
+    def _load_earliest(shelf: Shelf) -> int:
+        val = shelf.get('earliest')
+        if val is not None:
+            return val
+        return min([int(x) for x in shelf.keys() if x.isdecimal()] + [0])
+
+    @staticmethod
+    def _load_latest(shelf: Shelf) -> int:
+        val = shelf.get('latest')
+        if val:
+            return val
+        return max([int(x) for x in shelf.keys() if x.isdecimal()] + [0])
+
+    def load(self, *args, **kwargs) -> List[dict]:
+        return self._shelf_wrapper(True, self._load, *args, **kwargs)
+
+    @staticmethod
+    def _load(shelf: Shelf, block: int, index: Optional[int] = None) -> List[dict]:
+        retry = 10
+        while retry > 0:
+            try:
+                if block > shelf['latest']:
+                    raise BlockNotFound('Block not found')
+                break
+            except KeyError:  # may conflict with storing process
+                sleep(1)
+                retry -= 1
+        if retry <= 0:
+            raise Exception('Cannot get latest')
+        if index is None:
+            return shelf.get(str(block), [])  # all tx in block
+        return shelf.get(str(block))[index:index + 1]  # indexed tx only
+
+    def store(self, *args, **kwargs):
+        self._shelf_wrapper(False, self._store, *args, **kwargs)
+
+    def _store(self, shelf: Shelf, block: int, index: int, tx0: dict,
+               hardlimit=None, softlimit=None):
+        txs = shelf.get(str(block)) or []
+        assert index == 0 or len(txs) >= index
+        if len(txs) == index:
+            txs.append(tx0)
+        else:
+            txs[index] = tx0  # overwrite
+        shelf[str(block)] = txs  # {block: [tx0, tx1, ...]}
+
+        if shelf.get('earliest') is None or self.earliest > block:
+            shelf['earliest'] = self.earliest = block
+        if block > shelf.get('latest', 0):
+            shelf['latest'] = block
+
+        if hardlimit:
+            if softlimit is None:
+                softlimit = hardlimit
+            self._shrink_by_amount(shelf, hardlimit, softlimit)
+
+    def _shrink_by_amount(self, shelf: Shelf, hardlimit: int, softlimit: int):
+        # shrink down to softlimit if exceeds hardlimit.
+        assert softlimit > 0
+        assert hardlimit >= softlimit
+        keys = [x for x in shelf.keys() if x.isdecimal()]
+        if len(keys) <= hardlimit:
+            return
+        victims = sorted(keys, key=int)[:-softlimit]
+        shelf['earliest'] = self.earliest = int(victims[-1]) + 1
+        for key in victims:
+            try:
+                del shelf[key]
+            except Exception:
+                pass  # may be deleted by another proc.
+
+    def shrink_by_blocknumber(self, *args, **kwargs):
+        self._shelf_wrapper(False, self._shrink_by_blocknumber, *args, **kwargs)
+
+    def _shrink_by_blocknumber(self, shelf: Shelf, shrink_before: int):
+        for key in [x for x in shelf.keys() if x.isdecimal() and int(x) < shrink_before]:
+            try:
+                del shelf[key]
+            except Exception:
+                pass  # may be deleted by another proc.
+        shelf['earliest'] = self.earliest = shrink_before

--- a/src/metemcyber/core/bc/monitor/tx_decoder.py
+++ b/src/metemcyber/core/bc/monitor/tx_decoder.py
@@ -1,0 +1,221 @@
+#
+#    Copyright 2021, NTT Communications Corp.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+import argparse
+import glob
+import json
+import os
+import pprint
+import sys
+from time import sleep
+from typing import Any, Dict, List, Tuple
+
+from eth_typing import ChecksumAddress
+from web3 import Web3
+from web3.exceptions import BlockNotFound
+
+from metemcyber.core.bc.monitor.tx_db import TransactionDB
+
+ABIS_DIR = f'{os.path.dirname(os.path.abspath(__file__))}/../contracts_data'
+
+
+class ABIManager:
+    abis: Dict[str, dict]  # {contract_id}-{contract_version} : abi
+    contracts: Dict[Any, str]  # contract : {contract_id}-{contract_version}
+    cached_contracts: Dict[ChecksumAddress, Any]  # to address: contract
+
+    def __init__(self):
+        self.abis = {}
+        self.contracts = {}
+        self.cached_contracts = {}
+        for comb_fname in glob.iglob(f'{ABIS_DIR}/*.combined.json-*'):
+            bname = os.path.basename(comb_fname)
+            contract_name = bname.split('.')[0]
+            contract_ver = bname.split('-')[-1]
+            contract_id = f'{contract_name}.sol:{contract_name}'
+            key = f'{contract_id}-{contract_ver}'
+            with open(comb_fname, 'r') as fin:
+                comb_json = json.load(fin)['contracts'][contract_id]
+            abi = json.loads(comb_json['metadata'])['output']['abi']
+            self.abis[key] = abi
+            contract = Web3().eth.contract(abi=abi)
+            self.contracts[contract] = key
+
+    @staticmethod
+    def fix_funcname(contract_key, func) -> str:
+        contract_name = contract_key.split(':')[-1]  # contains '-{version}'
+        contract_name = contract_name.split('-')[0]  # remove version
+        return f'{contract_name}.{func.fn_name}'
+
+    def decode(self, tx0: dict) -> dict:
+        to_addr = tx0.get('to')
+        input_data = tx0.get('input')
+
+        if not input_data:  # nothing to fix
+            return tx0
+
+        if not to_addr:  # maybe deploy
+            contract_address = tx0['x_tx_receipt'].get('contractAddress')
+            if contract_address:
+                tx0['deployed_address'] = contract_address
+                tx0['function'] = '(deploy)'
+                tx0['input'] = f'(bytecode length = {len(input_data)})'
+            else:
+                tx0['input'] = f'(data length = {len(input_data)})'
+            return tx0
+
+        if to_addr in self.cached_contracts.keys():  # use try cache
+            cache = self.cached_contracts[to_addr]
+            contract_key = self.contracts[cache]
+            try:
+                func, dec_data = cache.decode_function_input(input_data)
+                tx0['function'] = self.fix_funcname(contract_key, func)
+                tx0['input'] = dec_data
+                return tx0
+            except Exception:
+                pass
+
+        for contract, contract_key in self.contracts.items():  # try with any
+            try:
+                func, dec_data = contract.decode_function_input(input_data)
+                tx0['function'] = self.fix_funcname(contract_key, func)
+                tx0['input'] = dec_data
+                return tx0
+            except Exception:
+                pass
+
+        # give up decoding
+        tx0['input'] = f'(data length = {len(input_data)})'
+        return tx0
+
+
+class TransactionDecoder:
+    tdb_raw: TransactionDB
+    tdb_dec: TransactionDB
+    abi_mgr: ABIManager
+    conf: dict
+
+    def __init__(self, config_filepath):
+        with open(config_filepath, 'r') as fin:
+            self.conf = json.load(fin).get('decoder', {})
+        self.tdb_raw = TransactionDB(None, self.conf['db_filepath_raw'])
+        endpoint = self.tdb_raw.get('endpoint') or ''
+        assert len(endpoint) > 0
+        self.tdb_dec = TransactionDB(endpoint, self.conf['db_filepath_decoded'])
+        self.abi_mgr = ABIManager()
+        self.tdb_dec.update('codesize', self.tdb_raw.get('codesize'))
+
+    def fix_startblock(self) -> int:
+        assert self.tdb_dec
+        tmp = int(self.conf.get('start_block', 1))
+        if tmp > 0:
+            return tmp
+        tmp += self.tdb_dec.latest
+        return tmp if tmp > 0 else 1
+
+    def simplify_tx(self, tx0: dict) -> dict:
+        skip_keys = {'blockHash', 'hash', 'nonce', 'r', 's', 'v', 'x_tx_receipt'}
+        skip_keys_on_zero = {'to', 'input', 'value'}
+        status = tx0.get('x_tx_receipt', {}).get('status')
+        if status is not None:
+            tx0['x_receipt_status'] = status
+        if tx0.get('input'):
+            tx0 = self.abi_mgr.decode(tx0)
+        for key in skip_keys:
+            tx0.pop(key, None)
+        for key in skip_keys_on_zero:
+            if tx0.get(key):
+                continue
+            del tx0[key]
+        return tx0
+
+    def run(self):
+        assert self.tdb_raw
+        assert self.tdb_dec
+        print_blocknum = bool(self.conf.get('print_blocknum', True))
+        print_decoded = bool(self.conf.get('print_decoded', False))
+        exit_on_head = bool(self.conf.get('exit_on_head', False))
+        ext_lf = '\n' if print_blocknum else ''
+        block = self.fix_startblock()
+
+        self.tdb_raw.open(readonly=True)  # start with keep-alive mode
+        self.tdb_dec.open(readonly=False)
+
+        try:
+            for block in self.tdb_raw.stored_blocks(minimum=block):
+                print(f'\r{block}' if print_blocknum else '', end='', file=sys.stderr)
+                for idx, tx0 in enumerate(self.tdb_raw.load(block, None)):
+                    tx0 = self.simplify_tx(dict(tx0))
+                    self.tdb_dec.store(block, idx, tx0)
+                    if print_decoded:
+                        pprint.pprint(tx0)
+        except KeyboardInterrupt:
+            self.tdb_dec.update_latest(block - 1)  # block may be incomplete
+            print(f'{ext_lf}decoder interrupted at block: {block}')
+            return
+
+        self.tdb_raw.close()  # switch out from keep-alive mode
+        self.tdb_dec.close()
+
+        block += 1
+        while True:
+            try:
+                print(f'\r{block}' if print_blocknum else '', end='', file=sys.stderr)
+                for idx, tx0 in enumerate(self.tdb_raw.load(block, None)):
+                    tx0 = self.simplify_tx(dict(tx0))
+                    self.tdb_dec.store(block, idx, tx0)
+                    if print_decoded:
+                        pprint.pprint(tx0)
+                # Note: skip updating latest if block has no txs, for performance.
+                block += 1
+                continue
+            except KeyboardInterrupt:
+                self.tdb_dec.update_latest(block - 1)  # block may be incomplete
+                print(f'{ext_lf}decoder interrupted at block: {block}')
+                return
+            except BlockNotFound:
+                if exit_on_head:
+                    self.tdb_dec.update_latest(block - 1)
+                    print(f'{ext_lf}decoder stopped at the head: {block}')
+                    return
+            try:
+                self.tdb_dec.update_latest(block - 1)  # lazy update
+                sleep(1)
+            except KeyboardInterrupt:
+                print(f'{ext_lf}decoder interrupted at block: {block}')
+                return
+        print(f'{ext_lf}decoder stopped by error at block: {block}')
+
+
+def main(args):
+    decoder = TransactionDecoder(args.config)
+    decoder.run()
+
+
+OPTIONS: List[Tuple[str, str, dict]] = [
+    ('-c', '--config', dict(action='store', required=True)),
+]
+ARGUMENTS: List[Tuple[str, dict]] = [
+]
+
+if __name__ == '__main__':
+    PARSER = argparse.ArgumentParser()
+    for sname, lname, opts in OPTIONS:
+        PARSER.add_argument(sname, lname, **opts)
+    for name, opts in ARGUMENTS:
+        PARSER.add_argument(name, **opts)
+    ARGS = PARSER.parse_args()
+    main(ARGS)

--- a/src/metemcyber/core/bc/monitor/tx_dumper.py
+++ b/src/metemcyber/core/bc/monitor/tx_dumper.py
@@ -1,0 +1,138 @@
+#
+#    Copyright 2021, NTT Communications Corp.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+import argparse
+import json
+import sys
+from time import sleep
+from typing import List, Tuple
+
+from web3 import Web3
+from web3.exceptions import BlockNotFound, ExtraDataLengthError
+from web3.middleware import geth_poa_middleware
+from web3.providers.rpc import HTTPProvider
+
+from metemcyber.core.bc.monitor.tx_db import TransactionDB
+
+
+class TransactionDumper:
+    web3: Web3
+    tdb: TransactionDB
+    conf: dict
+    codesize: dict
+
+    def __init__(self, config_filepath):
+        with open(config_filepath, 'r') as fin:
+            self.conf = json.load(fin).get('dumper', {})
+        endpoint = self.conf['endpoint']
+        db_filepath = self.conf['db_filepath_raw']
+
+        self.web3 = Web3(HTTPProvider(endpoint))
+        try:
+            self.web3.eth.getBlock('latest')
+        except ExtraDataLengthError:
+            self.web3.middleware_onion.inject(geth_poa_middleware, layer=0)
+        self.tdb = TransactionDB(endpoint, db_filepath)
+        self.codesize = self.tdb.get('codesize') or {}
+
+    def fix_startblock(self) -> int:
+        assert self.tdb
+        tmp = int(self.conf.get('start_block', 1))
+        if tmp > 0:
+            return tmp
+        tmp += self.tdb.latest
+        return tmp if tmp > 0 else 1
+
+    def run(self):
+        assert self.web3
+        assert self.tdb
+        retry = retry_max = int(self.conf.get('retry_max', 10))
+        print_blocknum = bool(self.conf.get('print_blocknum', True))
+        ext_lf = '\n' if print_blocknum else ''
+        block = self.fix_startblock()
+
+        self.tdb.open()  # start with keep-alive mode
+
+        while retry >= 0:
+            try:
+                if print_blocknum:
+                    print(f'\r{block}', end='', file=sys.stderr)
+                num_tx = self.web3.eth.getBlockTransactionCount(block)
+                for i in range(num_tx):
+                    tx0 = dict(self.web3.eth.getTransactionByBlock(block, i))
+                    if tx0.get('hash'):
+                        # append tx_receipt as an extra data
+                        tx0['x_tx_receipt'] = dict(self.web3.eth.getTransactionReceipt(tx0['hash']))
+                    if self.codesize.get(tx0['from']) is None:
+                        self.codesize[tx0['from']] = len(self.web3.eth.getCode(tx0['from']))
+                    if tx0.get('to') and self.codesize.get(tx0['to']) is None:
+                        self.codesize[tx0['to']] = len(self.web3.eth.getCode(tx0['to']))
+                    self.tdb.store(block, i, tx0)  # latest is also updated
+                # Note: skip updating latest if num_tx is zero, for performance.
+                block += 1
+                retry = retry_max  # reset on succeeded
+                continue
+            except KeyboardInterrupt:
+                self.tdb.update_latest(block - 1)  # update before quit
+                self.tdb.update('codesize', self.codesize)
+                print(f'{ext_lf}dumper interrupted at block: {block}')
+                return
+            except BlockNotFound:
+                if self.conf.get('exit_on_head', False):
+                    self.tdb.update_latest(block - 1)
+                    self.tdb.update('codesize', self.codesize)
+                    print(f'{ext_lf}dumper stopped at the head: {block}')
+                    return
+                self.tdb.close(allow_redundant=True)  # switch out from keep-alive mode
+                sleep_sec = 1
+                retry = retry_max  # reset on polling
+            except Exception as err:
+                print(f'[ERROR] {err}')
+                sleep_sec = int(self.conf.get('retry_interval_sec', 1))
+                retry -= 1
+
+            try:
+                self.tdb.update_latest(block - 1)  # lazy update
+                self.tdb.update('codesize', self.codesize)
+                sleep(sleep_sec)
+            except KeyboardInterrupt:
+                print(f'{ext_lf}dumper interrupted at block: {block}')
+                return
+
+        self.tdb.update_latest(block - 1)
+        self.tdb.update('codesize', self.codesize)
+        print(f'{ext_lf}dumper stopped by error at block: {block}')
+
+
+def main(args):
+    dumper = TransactionDumper(args.config)
+    dumper.run()
+
+
+OPTIONS: List[Tuple[str, str, dict]] = [
+    ('-c', '--config', dict(action='store', required=True)),
+]
+ARGUMENTS: List[Tuple[str, dict]] = [
+]
+
+if __name__ == '__main__':
+    PARSER = argparse.ArgumentParser()
+    for sname, lname, opts in OPTIONS:
+        PARSER.add_argument(sname, lname, **opts)
+    for name, opts in ARGUMENTS:
+        PARSER.add_argument(name, **opts)
+    ARGS = PARSER.parse_args()
+    main(ARGS)

--- a/src/metemcyber/core/bc/monitor/tx_metadata_manager.py
+++ b/src/metemcyber/core/bc/monitor/tx_metadata_manager.py
@@ -1,0 +1,316 @@
+#
+#    Copyright 2021, NTT Communications Corp.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+import argparse
+import json
+import sys
+from time import sleep
+from typing import Any, Dict, List, Optional, Tuple
+
+from eth_typing import ChecksumAddress
+from web3.exceptions import BlockNotFound
+
+from metemcyber.core.bc.monitor.tx_db import TransactionDB
+
+DEPLOYERS: Dict[ChecksumAddress, ChecksumAddress] = {}
+CONTRACTS: Dict[ChecksumAddress, 'Contract'] = {}
+CONTRACT_CLASSES: Dict[str, type] = {}
+
+
+class Contract:
+    address: ChecksumAddress
+    version: int
+    deployer: Optional[ChecksumAddress]
+    meta: Dict[str, Any]
+
+    @property
+    def name(self) -> str:
+        return self.__class__.__name__
+
+    def __init__(self, address: ChecksumAddress, version: int = 0,
+                 deployer: Optional[ChecksumAddress] = None,
+                 meta: Optional[dict] = None):
+        self.address = address
+        self.version = version
+        self.deployer = deployer or DEPLOYERS.get(address)
+        self.meta = meta or {}
+        CONTRACTS[address] = self
+
+    def to_dict(self) -> dict:
+        return {
+            'address': self.address,
+            'name': self.name,
+            'version': self.version,
+            'deployer': self.deployer,
+            'meta': self.meta,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> 'Contract':
+        contract_class = CONTRACT_CLASSES.get(data['name'])
+        assert contract_class
+        contract = contract_class(
+            data['address'], data['version'], data.get('deployer'), data.get('meta', {}))
+        return contract
+
+    def update(self, tx0):
+        pass
+
+
+class CTIToken(Contract):
+    def update(self, tx0):
+        cname, func = tx0['function'].split('.', 1)
+        assert self.name == cname
+        if func in {'setEditable', 'addCandidates', 'removeCandidates', 'vote'}:
+            self.version = max(self.version, 1)
+            if func == 'setEditable':
+                self.meta['editable'] = tx0['input']['anyoneEditable']
+            elif func == 'addCandidates':
+                self.meta['candidates'] = self.meta.get('candidates') or {}
+                for desc in tx0['input']['new_candidates']:
+                    index = len(self.meta['candidates'].keys())
+                    self.meta['candidates'][index] = {
+                        'index': index,
+                        'score': 0,
+                        'desc': desc,
+                    }
+            elif func == 'removeCandidates':
+                self.meta['candidates'] = self.meta.get('candidates') or {}
+                for index in tx0['input']['indexes']:
+                    self.meta['candidates'][index].desc += ' (REMOVED)'  # fake remove
+            elif func == 'vote':
+                self.meta['candidates'] = self.meta.get('candidates') or {}
+                self.meta['candidates'][tx0['input']['idx']]['score'] += tx0['input']['amount']
+
+
+class CTICatalog(Contract):
+    def update(self, tx0):
+        cname, func = tx0['function'].split('.', 1)
+        assert self.name == cname
+        if func in {'setMembers'}:
+            self.version = max(self.version, 1)
+            if func == 'setMembers':
+                self.meta['members'] = tx0['input']['members_']
+        elif func in {'setPrivate', 'setPublic', 'authrizeUser', 'revokeUser'}:
+            self.version = 0
+        elif func in {'registerCti', 'modifyCti'}:
+            token_address = tx0['input']['tokenURI']
+            self.meta['tokens'] = self.meta.get('tokens') or {}
+            self.meta['tokens'][token_address] = {
+                'uuid': tx0['input']['uuid'],
+                'title': tx0['input']['title'],
+                'price': tx0['input']['price'],
+                'operator': tx0['input']['operator'],
+            }
+            token = CONTRACTS.get(token_address) or CTIToken(token_address)
+            token.meta['catalogs'] = token.meta.get('catalogs', [])
+            if self.address not in token.meta['catalogs']:
+                token.meta['catalogs'].append(self.address)
+        elif func == 'unregisterCti':
+            token_address = tx0['input']['tokenURI']
+            self.meta['tokens'][token_address]['title'] += ' (REMOVED)'  # fake remove
+            token = CONTRACTS.get(token_address) or CTIToken(token_address)
+            if self.address in token.meta.get('catalogs', []):
+                token.meta['catalogs'].remove(self.address)
+
+
+class CTIBroker(Contract):
+    pass
+
+
+class CTIOperator(Contract):
+    def update(self, tx0):
+        cname, func = tx0['function'].split('.', 1)
+        assert self.name == cname
+        if func == 'history' and 'seeker' in tx0['input'].keys():
+            self.version = max(self.version, 1)
+
+
+class AddressGroup(Contract):
+    pass
+
+
+CONTRACT_CLASSES = {
+    'CTIToken': CTIToken,
+    'CTICatalog': CTICatalog,
+    'CTIBroker': CTIBroker,
+    'CTIOperator': CTIOperator,
+    'AddressGroup': AddressGroup,
+}
+
+
+class MetadataManager:
+    conf: dict
+    tdb_dec: Optional[TransactionDB]
+    tdb_meta: TransactionDB
+    codesize: Dict[ChecksumAddress, int]
+
+    def __new__(cls, *_args, **_kwargs):
+        if not hasattr(cls, '_instance'):
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __init__(self, config_filepath: str, readonly=False):
+        if hasattr(self, 'conf') and self.conf:  # already initialized
+            return
+        with open(config_filepath, 'r') as fin:
+            self.conf = json.load(fin).get('metadata_manager', {})
+        if readonly:
+            self.tdb_dec = endpoint = None
+        else:
+            self.tdb_dec = TransactionDB(None, self.conf['db_filepath_decoded'])
+            endpoint = self.tdb_dec.get('endpoint')
+            assert endpoint and len(endpoint) > 0
+            self.codesize = self.tdb_dec.get('codesize')
+        self.tdb_meta = TransactionDB(endpoint, self.conf['db_filepath_meta'])
+        self._load_meta()
+
+    def _load_meta(self):
+        # pylint: disable=global-statement
+        global DEPLOYERS, CONTRACTS
+        assert not DEPLOYERS and not CONTRACTS
+        DEPLOYERS.update(self.tdb_meta.get('deployers') or {})
+        CONTRACTS.update({
+            val['address']: Contract.from_dict(val)
+            for val in (self.tdb_meta.get('contracts') or {}).values()
+        })
+
+    def _save_meta(self):
+        self.tdb_meta.update('deployers', DEPLOYERS)
+        self.tdb_meta.update('contracts', {addr: cnt.to_dict() for addr, cnt in CONTRACTS.items()})
+
+    @staticmethod
+    def get(address: ChecksumAddress) -> dict:
+        if address not in CONTRACTS.keys():
+            return {}
+        return CONTRACTS[address].to_dict()
+
+    @staticmethod
+    def get_tokeninfo(token_address: ChecksumAddress,
+                      catalog_address: Optional[ChecksumAddress] = None) -> Optional[dict]:
+        token = CONTRACTS.get(token_address)
+        if not token:
+            return None
+        if not catalog_address:
+            if len(token.meta.get('catalogs', [])) == 0:  # not registered
+                return None
+            catalog_address = token.meta['catalogs'][-1]  # registered catalog at last
+        assert catalog_address
+        catalog = CONTRACTS.get(catalog_address)
+        assert catalog
+        return catalog.meta.get('tokens', {}).get(token_address, {})
+
+    def fix_startblock(self) -> int:
+        tmp = int(self.conf.get('start_block', 1))
+        if tmp > 0:
+            return tmp
+        tmp += self.tdb_meta.latest
+        return tmp if tmp > 0 else 1
+
+    def apply_tx(self, tx0):
+        function = tx0.get('function')
+        if not function:
+            return
+        status = tx0.get('x_receipt_status', 0)
+        if status != 1:  # ignore reverted transaction
+            return
+        if function == '(deploy)':
+            DEPLOYERS[tx0['deployed_address']] = tx0['from']
+            return
+        address = tx0['to']
+        if self.codesize.get(address) == 0:  # address is EOA
+            return
+
+        cname, _func = tx0['function'].split('.', 1)
+        contract = CONTRACTS.get(address)
+        if not contract:
+            contract = CONTRACT_CLASSES.get(cname)(address)
+        contract.update(tx0)
+
+    def run(self):
+        if not self.tdb_dec:
+            raise Exception('ReadonlyMode')
+
+        print_blocknum = bool(self.conf.get('print_blocknum', True))
+        exit_on_head = bool(self.conf.get('exit_on_head', False))
+        ext_lf = '\n' if print_blocknum else ''
+        block = self.fix_startblock()
+
+        self.tdb_dec.open(readonly=True)  # start with keep-alive mode
+        self.tdb_meta.open(readonly=False)
+
+        try:
+            for block in self.tdb_dec.stored_blocks(minimum=block):
+                print(f'\r{block}' if print_blocknum else '', end='', file=sys.stderr)
+                for tx0 in self.tdb_dec.load(block, None):
+                    self.apply_tx(tx0)
+        except KeyboardInterrupt:
+            self._save_meta()
+            self.tdb_meta.update_latest(block - 1)
+            print(f'{ext_lf}metadata_manager interrupted at block: {block}')
+            return
+
+        self.tdb_dec.close()  # switch out from keep-alive mode
+        self.tdb_meta.close()
+
+        block += 1
+        while True:
+            try:
+                print(f'\r{block}' if print_blocknum else '', end='', file=sys.stderr)
+                for tx0 in self.tdb_dec.load(block, None):
+                    self.apply_tx(tx0)
+                block += 1
+                continue
+            except KeyboardInterrupt:
+                self._save_meta()
+                self.tdb_meta.update_latest(block - 1)
+                print(f'{ext_lf}metadata_manager interrupted at block: {block}')
+                return
+            except BlockNotFound:
+                if exit_on_head:
+                    self._save_meta()
+                    self.tdb_meta.update_latest(block - 1)
+                    print(f'{ext_lf}metadata_manager stopped at the head: {block}')
+                    return
+            try:
+                self._save_meta()
+                self.tdb_meta.update_latest(block - 1)
+                sleep(1)
+            except KeyboardInterrupt:
+                print(f'{ext_lf}metadata_manager interrupted at block: {block}')
+                return
+        print(f'{ext_lf}metadata_manager stopped by error at block: {block}')
+
+
+def main(args):
+    meta_mgr = MetadataManager(args.config)
+    meta_mgr.run()
+
+
+OPTIONS: List[Tuple[str, str, dict]] = [
+    ('-c', '--config', dict(action='store', required=True)),
+]
+ARGUMENTS: List[Tuple[str, dict]] = [
+]
+
+if __name__ == '__main__':
+    PARSER = argparse.ArgumentParser()
+    for sname, lname, opts in OPTIONS:
+        PARSER.add_argument(sname, lname, **opts)
+    for name, opts in ARGUMENTS:
+        PARSER.add_argument(name, **opts)
+    ARGS = PARSER.parse_args()
+    main(ARGS)

--- a/src/metemcyber/core/bc/monitor/tx_util.py
+++ b/src/metemcyber/core/bc/monitor/tx_util.py
@@ -1,0 +1,68 @@
+#
+#    Copyright 2021, NTT Communications Corp.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+from typing import Any, List, Optional
+
+
+def safe_inc(base: Optional[dict], keys: List[str]) -> dict:
+    tgt = base if base is not None else dict()
+    tmp = tgt
+    for key in keys[:-1]:  # fix branches
+        if key not in tmp.keys():
+            tmp[key] = dict()
+        tmp = tmp[key]
+    if keys[-1] not in tmp.keys():  # fix leaf
+        tmp[keys[-1]] = 0
+    tmp[keys[-1]] += 1
+    return tgt
+
+
+def safe_set(base: Optional[dict], keys: List[str], val: Any) -> dict:
+    tgt = base if base is not None else dict()
+    tmp = tgt
+    for key in keys[:-1]:
+        if key not in tmp.keys():
+            tmp[key] = dict()
+        tmp = tmp[key]
+    tmp[keys[-1]] = val
+    return tgt
+
+
+def safe_dec(base: Optional[dict], keys: List[str]) -> dict:
+    if base is None:
+        return dict()
+    tgt = base
+    tmp = tgt
+    for key in keys[:-1]:
+        if key not in tmp.keys():  # no such leaf to decrement.
+            return tgt
+        tmp = tmp[key]
+    if keys[-1] not in tmp.keys():  # no such leaf to decrement.
+        return tgt
+    if tmp[keys[-1]] > 1:
+        tmp[keys[-1]] -= 1
+        return tgt
+    _recursive_delete(tgt, keys, 0)
+    return tgt
+
+
+def _recursive_delete(base: dict, keys: List[str], depth: int):
+    if depth == len(keys):
+        del base[keys[depth]]  # delete leaf
+        return
+    _recursive_delete(base[keys[depth]], keys, depth + 1)
+    if not base[keys[depth]]:
+        del base[keys[depth]]  # delete if the branch comes to be empty.

--- a/tx_monitor.conf.tmpl
+++ b/tx_monitor.conf.tmpl
@@ -1,0 +1,28 @@
+{
+    "dumper": {
+        "endpoint": "https://rpc.metemcyber.ntt.com",
+        "db_filepath_raw": "tx_shelf.raw.db",
+        "start_block": 0,
+        "print_blocknum": true,
+        "exit_on_head": true},
+    "decoder": {
+        "db_filepath_raw": "tx_shelf.raw.db",
+        "db_filepath_decoded": "tx_shelf.db",
+        "start_block": 0,
+        "exit_on_head": true,
+        "print_blocknum": true,
+        "print_decoded": true},
+    "metadata_manager": {
+        "db_filepath_decoded": "tx_shelf.db",
+        "db_filepath_meta": "tx_shelf.meta.db",
+        "start_block": 0,
+        "exit_on_head": true,
+        "print_blocknum": true},
+    "counter": {
+        "db_filepath_decoded": "tx_shelf.db",
+        "db_filepath_meta": "tx_shelf.meta.db"},
+    "slack_notifier": {
+        "webhook": "Your IncommingWebhook URL. ex) https://hooks.slack.com/services/T01FJ...",
+        "channel": "Channel name to post. ex) #dev",
+        "appname": "Metembot"}
+}


### PR DESCRIPTION
トランザクションモニタおよび Slack 通知機能を実装（旧版から移植）しました。
- パッケージ的な配置は未検討です。config のテンプレートもルート直下に仮置きしてます。
- トランザクション情報は 3 種の db に分けて格納しています。これは再実行時の処理コストを低減するためです。
- tx_dumper.py は endpoint に接続し、各トランザクションとレシート、付帯情報として from アドレスの CodeSize をraw db に収集します。endpoint に接続する処理は tx_dumper.py のみです。
- tx_decoder.py は raw db に格納された各トランザクションを解析・簡略化して decoded db に格納します。解析の際には contracts_data の各種 combined_json を使用します。raw db の CodeSize 情報を丸っとコピーしてますが、これは meta で必要なためです。
- tx_metadata_manager.py は decoded db のトランザクション情報から、各アドレスの実体を推測し、meta db に格納します。推測は完全ではなく、判断基準となる特徴的なトランザクションが存在しないと推測できません。
- tx_counter.py は、decoded db と meta db からトランザクションの統計情報を生成します。現在は WAICU/WAIPU の集計と、全トランザクションの単純カウントの 2 種のみが実装してあります。今後、必要に応じて追加します。
- slack_notifier.py は tx_counter.py の結果を slack 向けに整形し、incoming webhook を介して通知します。

tx_dumper.py の処理は endpoint との通信が、ブロック数に比例した回数必要です。初回実行には(現時点で)1,000万近いブロックを処理しなければなりません。websocket とか使えれば高速化できそうな気もしますが、実現できていません（試みて敗北しました）。