### PR TITLE
support solver with another EOA

### DIFF
--- a/src/metemcyber/core/bc/cti_token.py
+++ b/src/metemcyber/core/bc/cti_token.py
@@ -50,7 +50,7 @@ class CTIToken(Contract):
             raise ValueError('Transaction failed: mint')
         self.log_success()
 
-    def send_token(self, dest, amount=1, data=''):
+    def send(self, dest, amount=1, data=''):
         self.log_trace()
         bdata = Web3.toBytes(text=data)
         func = self.contract.functions.send(dest, amount, bdata)
@@ -61,7 +61,7 @@ class CTIToken(Contract):
             raise ValueError('Transaction failed: send')
         self.log_success()
 
-    def burn_token(self, amount, data=''):
+    def burn(self, amount, data=''):
         self.log_trace()
         bdata = Web3.toBytes(text=data)
         func = self.contract.functions.burn(amount, bdata)
@@ -91,6 +91,11 @@ class CTIToken(Contract):
         if tx_receipt['status'] != 1:
             raise ValueError('Transaction failed: revokeOperator')
         self.log_success()
+
+    def is_operator(self, operator: ChecksumAddress, token_holder: ChecksumAddress) -> bool:
+        self.log_trace()
+        func = self.contract.functions.isOperatorFor(operator, token_holder)
+        return func.call()
 
     @property
     def editable(self) -> bool:


### PR DESCRIPTION
solver を通常アカウントとは別の EOA で運用できるように改修しました。
- config の general.solver_keyfile で solver 用の keyfile を設定します。デフォルト（empty）設定の場合、これまでと同様に通常アカウントを適用します。
- general.solver_keyfile_password には solver 用 keyfile のパスワードを設定しておけます。未設定の場合、通常アカウントのデコードと同じ処理（環境変数未設定なら入力プロンプト）が走ります。solver 用と通常用、両者のパスワードを同一にしておくのが楽かもしれません。（solver の自動起動で事情が変わりそうな気はしてますが）
- 影響範囲は当初想定より広かったため、ctx に solver_account の概念を追加し、solver_client 取得時にロードするようにしました。cli で solver を参照する箇所には全て solver_account が適用されます。ix search での accepting マークも solver_account が返しています。
- seeker が webhook で受信したデータを検証する際、signer(solver) が token の operator であることをチェックするようにしました。事前に token_publish で（必要があれば）solver を authorizeOperator しています。
- token publisher は無条件で operator 判定されるため、既に運用されているトークンも（通常 EOA で solver を運用するなら）正常に処理できます。（後付で authorize, revoke する機能も必要だと思いますが、現在は未実装です）

アップデート時の注意点です。
- solver の enable, disable, status は solver_account （のみ）が対象です。
- ただし、stop するとプロセスごとダウンするため全 EOA の solver スレッドが停止します。

従来の（通常アカウントを適用した）solver が enable な状態で config edit して solver_keyfile を変更し、enable, support すると、通常 EOA ＋ solver_account の２つの solver が別スレッドで同居する状態になります。この状態で ix use すると、両方の solver が accept しようと動作します（一方は revert される）。紛らわしいので、solver 設定の変更時は solver stop しておいた方が無難かもしれません。