### PR TITLE
start seeker&ngrok at ix-use if not launched

### DIFF
--- a/src/metemcyber/core/ngrok.py
+++ b/src/metemcyber/core/ngrok.py
@@ -104,7 +104,7 @@ class NgrokMgr():
                                f'web_addr: localhost:{port}\n')
                 # ngrok needs to keep running in the background
                 # pylint pylint: disable=R1732
-                proc = Popen(args, shell=False)
+                proc = Popen(args, shell=False, start_new_session=True)
                 try:
                     proc.wait(timeout=1)  # may exit with 'Address already in use'
                     del proc

--- a/src/metemcyber/core/seeker.py
+++ b/src/metemcyber/core/seeker.py
@@ -240,7 +240,7 @@ class Seeker():
             raise Exception(f'Already running on pid({self.pid}).')
         # Seeker needs to keep running in the background.
         # pylint pylint: disable=R1732
-        proc = Popen(self.cmd_args, shell=False)
+        proc = Popen(self.cmd_args, shell=False, start_new_session=True)
         for _cnt in range(5):
             sleep(1)
             self.pid, self.address, self.port = self.check_running()


### PR DESCRIPTION
ix-use で seeker を自動起動するように改修しました。
- コマンドオプションで ngrok を有効化する機能を廃止しました。頻繁に変化するパラメータではありませんので、config でのみ設定変更可能とします。
- 自動起動した場合、ix-use が seeker メッセージの表示を終了するための KeyboardInterrupt を Seeker, Ngrok が受け取ってプロセス終了してしまう問題があり、回避するために Popen に start_new_session=True を設定しました。マニュアルによると「POSIX でのみ有効」らしく、MacOS で正常動作するかは未確認です。