### PR TITLE
Topic/filter for tx monitor

### DIFF
--- a/src/metemcyber/core/bc/monitor/slack_notifier.py
+++ b/src/metemcyber/core/bc/monitor/slack_notifier.py
@@ -191,7 +191,7 @@ def parse_queries(queries: List[dict]) -> List[
 def main(args):
     notifier = SlackNotifier(args.config, testmode=args.testmode)
     with open(args.config, 'r') as fin:
-        queries = json.load(fin).get('queries', [])
+        queries = [q for q in json.load(fin).get('queries', []) if not q.get('disable')]
     for gclass, cclass, options in parse_queries(queries):
         generator = gclass()
         counter = cclass(args.config, options)

--- a/tx_monitor.conf.tmpl
+++ b/tx_monitor.conf.tmpl
@@ -49,7 +49,7 @@
                     "include_from": [],
                     "exclude_from": []
                 },
-                "days": 70,
-                "reverted": "no"}}
+                "days": 7,
+                "reverted": "yes"}}
     ]
 }

--- a/tx_monitor.conf.tmpl
+++ b/tx_monitor.conf.tmpl
@@ -32,7 +32,10 @@
                 "waixu_filter": {
                     "include_catalogs": [
                          "0xBcb4b84cdaB65C6e6Efe1697CC41a46D0AEaCA61",
-                         "0x168DD95472cEaF5c28447C8b07A593e205E92A12"]
+                         "0x168DD95472cEaF5c28447C8b07A593e205E92A12"],
+                    "exclude_catalogs": [],
+                    "include_brokers": [],
+                    "exclude_brokers": []
                 },
                 "days": 7,
                 "hours": 0}},
@@ -40,7 +43,13 @@
             "class": "Simple",
             "disable": 1,
             "options": {
-                "days": 7,
-                "reverted": "yes"}}
+                "generic_filter": {
+                    "include_to": [],
+                    "exclude_to": [],
+                    "include_from": [],
+                    "exclude_from": []
+                },
+                "days": 70,
+                "reverted": "no"}}
     ]
 }

--- a/tx_monitor.conf.tmpl
+++ b/tx_monitor.conf.tmpl
@@ -24,5 +24,17 @@
     "slack_notifier": {
         "webhook": "Your IncommingWebhook URL. ex) https://hooks.slack.com/services/T01FJ...",
         "channel": "Channel name to post. ex) #dev",
-        "appname": "Metembot"}
+        "appname": "Metembot"},
+    "queries": [
+        {
+            "class": "Waixu",
+            "options": {
+                "days": 7,
+                "hours": 0}},
+        {
+            "class": "Simple",
+            "options": {
+                "days": 7,
+                "reverted": "yes"}}
+    ]
 }

--- a/tx_monitor.conf.tmpl
+++ b/tx_monitor.conf.tmpl
@@ -29,10 +29,16 @@
         {
             "class": "Waixu",
             "options": {
+                "waixu_filter": {
+                    "include_catalogs": [
+                         "0xBcb4b84cdaB65C6e6Efe1697CC41a46D0AEaCA61",
+                         "0x168DD95472cEaF5c28447C8b07A593e205E92A12"]
+                },
                 "days": 7,
                 "hours": 0}},
         {
             "class": "Simple",
+            "disable": 1,
             "options": {
                 "days": 7,
                 "reverted": "yes"}}


### PR DESCRIPTION
トランザクションモニタにフィルタ機能を実装しました。
- 集計する内容を引数で指定する形態を廃止し、config ファイル内の queries で指定する形態に変更しました。
- generic_filter は汎用的に使えるフィルタで、単純にトランザクションの from, to でフィルタします。
- waixu_filter は WAIxU 専用のフィルタで、カタログ・ブローカーでフィルタします。

いずれのフィルタもトランザクションの内容をある程度把握していないと使いこなせませんが、モニタを使う時点で求められるので仕方ないです。