### PR TITLE
 Fix cancel challange and execution of node-pty

### DIFF
--- a/gui/package-lock.json
+++ b/gui/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "Metemcyber",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5255,6 +5255,11 @@
         "ip-regex": "^2.1.0"
       }
     },
+    "default-shell": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/default-shell/-/default-shell-1.0.1.tgz",
+      "integrity": "sha1-dSMEvdxhdPSespy5iP7qC4gTyLw="
+    },
     "defer-to-connect": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
@@ -7098,6 +7103,14 @@
       "requires": {
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
+      }
+    },
+    "fix-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fix-path/-/fix-path-3.0.0.tgz",
+      "integrity": "sha512-opGAl4+ip5jUikHR2C8Jo7czZ80pz8EK/0gMlAZu7xgDmBqIynlX8SMYg9KowYjAU6HT0nxsSJEWru0u+n+N2Q==",
+      "requires": {
+        "shell-path": "^2.1.0"
       }
     },
     "flat-cache": {
@@ -12710,6 +12723,11 @@
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
       "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
     },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+    },
     "psl": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
@@ -13089,6 +13107,11 @@
       "version": "6.0.9",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
       "integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew=="
+    },
+    "react-heatmap-grid": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/react-heatmap-grid/-/react-heatmap-grid-0.8.2.tgz",
+      "integrity": "sha512-kvBGf4s3OZvXCgmLdh6CG2n0s1GZN1EAwBf8SRGHgFQmBKFhjp1pDMRw3fDm9OD83A1/rCqyyuVd4yODx7n0vA=="
     },
     "react-is": {
       "version": "17.0.1",
@@ -14460,6 +14483,85 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+    },
+    "shell-env": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/shell-env/-/shell-env-0.3.0.tgz",
+      "integrity": "sha1-IlAzkCKYkWW9pOt784Ov6qqS3DQ=",
+      "requires": {
+        "default-shell": "^1.0.0",
+        "execa": "^0.5.0",
+        "strip-ansi": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+        },
+        "cross-spawn": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
+          "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "which": "^1.2.9"
+          }
+        },
+        "execa": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.5.1.tgz",
+          "integrity": "sha1-3j+4XLjW6RyFvLzrFkWBeFy1ezY=",
+          "requires": {
+            "cross-spawn": "^4.0.0",
+            "get-stream": "^2.2.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
+          "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
+          "requires": {
+            "object-assign": "^4.0.1",
+            "pinkie-promise": "^2.0.0"
+          }
+        },
+        "lru-cache": {
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+          "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+          "requires": {
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+        }
+      }
+    },
+    "shell-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/shell-path/-/shell-path-2.1.0.tgz",
+      "integrity": "sha1-6n0GrhBwh0obrFxlu5vdYuT2ejg=",
+      "requires": {
+        "shell-env": "^0.3.0"
+      }
     },
     "shell-quote": {
       "version": "1.7.2",

--- a/gui/package.json
+++ b/gui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Metemcyber",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "private": true,
   "main": "public/electron.js",
   "homepage": "./",
@@ -11,11 +11,13 @@
     "@testing-library/user-event": "^12.1.10",
     "bootstrap": "^4.6.0",
     "electron-is-dev": "^1.2.0",
+    "fix-path": "^3.0.0",
     "ngrok": "^3.4.0",
     "node-pty": "^0.10.0",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
     "react-dropzone": "^11.3.1",
+    "react-heatmap-grid": "^0.8.2",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.2",
     "reactstrap": "^8.9.0",
@@ -64,23 +66,6 @@
       "buildResources": "resources",
       "output": "dist"
     },
-    "extraFiles": [
-      {
-        "from": "../",
-        "to": "./metemcyber_contents",
-        "filter": [
-          "!gui/*",
-          "!.git/*",
-          "!.gitignore",
-          "!.gitmodules",
-          "!.readthedocs.yml"
-        ]
-      },
-      {
-        "from": "docker-path",
-        "to": "./"
-      }
-    ],
     "mac": {
       "target": "dmg",
       "icon": "public/logo512.png"

--- a/gui/public/electron.js
+++ b/gui/public/electron.js
@@ -295,6 +295,60 @@ ipcMain.on('buy', async (event, arg) => {
   event.reply('success-buy', "success");
 });
 
+ipcMain.on('challange', async (event, arg) => {
+  let returnVal = {
+    item: [],
+  };
+
+  let item = {
+    id: '',
+    name: '',
+    addr: '',
+    status: '',
+  };
+
+  proc = getProc(["metemctl", "ix", "show"]);
+
+  let outputStr = "";
+  proc.on('data', (data) => {
+    data.split("\r\n").map((val) => {
+      event.reply('send-log', val);
+      outputStr += val;
+    })
+  });
+  await onEnd(proc);
+
+  let outputs = outputStr.split(" ").filter(val => val !== '');
+
+  while (outputs.length > 0) {
+    item.id = outputs[0].slice(0, -1);
+    item.name = outputs.slice(1, outputs.indexOf('├')).join(" ");
+
+    outputs.splice(0, outputs.indexOf('├') + 1);
+
+    item.addr = outputs[1];
+    item.status = outputs[4];
+
+    returnVal.item.push(item);
+    item = {
+      id: '',
+      name: '',
+      addr: '',
+      status: '',
+    };
+    outputs.splice(0, 5);
+  }
+
+  event.reply('send-challangeList', returnVal);
+});
+
+ipcMain.on('cancel', async (event, arg) => {
+
+  proc = getProc(["metemctl", "ix", "cancel", arg]);
+  await onEnd(proc);
+  event.reply('success-cancel', "success");
+});
+
 ipcMain.on('get-key', async (event, arg) => {
   // get key path
   const keyProc = getProc(["metemctl", "config", "show"]);

--- a/gui/public/electron.js
+++ b/gui/public/electron.js
@@ -92,7 +92,7 @@ ipcMain.on('logout', async (event, arg) => {
 
 ipcMain.on('login', async (event, arg) => {
   process.env.METEMCTL_KEYFILE_PASSWORD = arg;
-  proc = getProc(["metemctl", "account", "show",]);
+  proc = getProc(["account", "show",]);
   proc.on('data', (data) => {
     data.split("\r\n").map((val) => {
       event.reply('send-log', val);
@@ -103,7 +103,7 @@ ipcMain.on('login', async (event, arg) => {
 });
 
 ipcMain.on('seeker', async (event, arg) => {
-  proc = getProc(["metemctl", "seeker", "status",]);
+  proc = getProc(["seeker", "status",]);
   outputStr = "";
   proc.on('data', (data) => {
     data.split("\r\n").map((val) => {
@@ -122,7 +122,7 @@ ipcMain.on('seeker', async (event, arg) => {
 });
 
 ipcMain.on('challange-start', async (event, arg) => {
-  const challangeProc = getProc(["metemctl", "ix", "use", arg]);
+  const challangeProc = getProc(["ix", "use", arg]);
   outputStr = "";
   let returnVal = {
     id: arg,
@@ -172,7 +172,7 @@ ipcMain.on('account', async (event, arg) => {
     tokens: []
   };
 
-  proc = getProc(["metemctl", "account", "show"]);
+  proc = getProc(["account", "show"]);
 
   let outputStr = "";
   proc.on('data', (data) => {
@@ -202,7 +202,7 @@ ipcMain.on('account', async (event, arg) => {
     returnVal.tokens.push(token);
   }
 
-  proc = getProc(["metemctl", "config", "show"]);
+  proc = getProc(["config", "show"]);
 
   outputStr = "";
   proc.on('data', (data) => {
@@ -246,7 +246,7 @@ ipcMain.on('token', async (event, arg) => {
     quantity: ''
   };
 
-  proc = getProc(["metemctl", "ix", "search", ' ']);
+  proc = getProc(["ix", "search", ' ']);
 
   let outputStr = "";
   proc.on('data', (data) => {
@@ -293,7 +293,7 @@ ipcMain.on('token', async (event, arg) => {
 
 ipcMain.on('buy', async (event, arg) => {
 
-  proc = getProc(["metemctl", "ix", "buy", arg]);
+  proc = getProc(["ix", "buy", arg]);
   await onEnd(proc);
   event.reply('success-buy', "success");
 });
@@ -310,7 +310,7 @@ ipcMain.on('challange', async (event, arg) => {
     status: '',
   };
 
-  proc = getProc(["metemctl", "ix", "show"]);
+  proc = getProc(["ix", "show"]);
 
   let outputStr = "";
   proc.on('data', (data) => {
@@ -347,14 +347,14 @@ ipcMain.on('challange', async (event, arg) => {
 
 ipcMain.on('cancel', async (event, arg) => {
 
-  proc = getProc(["metemctl", "ix", "cancel", arg]);
+  proc = getProc(["ix", "cancel", arg]);
   await onEnd(proc);
   event.reply('success-cancel', "success");
 });
 
 ipcMain.on('get-key', async (event, arg) => {
   // get key path
-  const keyProc = getProc(["metemctl", "config", "show"]);
+  const keyProc = getProc(["config", "show"]);
 
   let outputStr = "";
   keyProc.on('data', (data) => {
@@ -406,7 +406,7 @@ ipcMain.on('set-key', async (event, arg) => {
 });
 
 ipcMain.on('open-download-dir', async (event, arg) => {
-  const downloadProc = getProc(["metemctl", "config", "show"]);
+  const downloadProc = getProc(["config", "show"]);
 
   let outputStr = "";
   downloadProc.on('data', (data) => {
@@ -441,7 +441,7 @@ function execLogout() {
 
 function getProc(commands) {
   console.log(commands)
-  return pty.spawn('bash', commands, nodePtyConfig);
+  return pty.spawn('metemctl', commands, nodePtyConfig);
 };
 
 function onEnd(proc) {

--- a/gui/public/electron.js
+++ b/gui/public/electron.js
@@ -21,6 +21,7 @@ const isDev = require("electron-is-dev");
 const pty = require('node-pty');
 const fs = require('fs');
 const exec = require('util').promisify(require('child_process').exec);
+const fixPath = require('fix-path');
 
 let proc = null;
 
@@ -51,6 +52,8 @@ async function createWindow() {
       ? "http://localhost:3000/login"
       : `file://${path.join(__dirname, "../build/index.html")}`
   );
+
+  fixPath();
 
   // Open the DevTools.
   mainWindow.webContents.openDevTools()

--- a/gui/src/containers/Challange/cancel.js
+++ b/gui/src/containers/Challange/cancel.js
@@ -16,26 +16,20 @@
 
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
-import { Badge, Button, Card, CardHeader, CardBody, Col, Container, Input, InputGroup, InputGroupAddon, List, ListInlineItem, Modal, ModalBody, ModalFooter, Row } from 'reactstrap';
+import { Badge, Button, Card, CardHeader, CardBody, Col, Container, Input, InputGroup, InputGroupAddon, List, ListInlineItem, Modal, ModalBody, ModalFooter, Row, Spinner } from 'reactstrap';
 import '../default.css';
 
 
 
 function Cancel(props) {
     const { ipcRenderer } = window;
-    const [content, setContent] = useState([]);
-    const [isLoading, setIsLoading] = useState(true);
-    const [searchText, setSearchText] = useState(sessionStorage.getItem('searchText'));
+    const [isLoading, setIsLoading] = useState(false);
+    const [searchText, setSearchText] = useState('');
     const [modalToggle, setModalToggle] = useState(false);
     const [targetId, setTargetId] = useState('');
     const [split, setSplit] = useState('12');
 
     useEffect(() => {
-        console.log(sessionStorage.getItem('searchText'));
-        const retValue = ipcRenderer.sendSync('select-menu', '12');
-        console.log(retValue)
-        setContent(retValue);
-        setIsLoading(false);
         return () => console.log('unmounting...');
     }, [])
     const toggle = (e) => {
@@ -48,25 +42,20 @@ function Cancel(props) {
     }
 
     const handleSearch = () => {
-        sessionStorage.setItem('searchText', searchText);
-        const retValue = ipcRenderer.sendSync('select-12', ['s', searchText]);
-        console.log(retValue)
-        setContent(retValue);
     }
 
     const handleRelease = () => {
-        sessionStorage.setItem('searchText', '');
-        const retValue = ipcRenderer.sendSync('select-12', ['a']);
-        console.log(retValue)
         setSearchText('');
-        setContent(retValue);
     }
 
-    const handleExecution = () => {
-        const retValue = ipcRenderer.sendSync('select-12', [targetId]);
-        console.log(retValue)
-        setContent(retValue);
-        setModalToggle(!modalToggle);
+    const handleExecution = async () => {
+        setIsLoading(true);
+        ipcRenderer.send('cancel', targetId);
+        ipcRenderer.once('success-cancel', async (event, arg) => {
+            console.log(arg);
+            await props.refreshInfo();
+            setModalToggle(!modalToggle);
+        });
     }
 
     const handleSplit = (e) => {
@@ -75,39 +64,32 @@ function Cancel(props) {
 
     return (
         <div>
-            {isLoading ?
-                <div>
-                    Loading...
-                </div>
-                :
-                <Container>
-                    <MainContent>
-                        <Row>
-                            <Col>
-                                <div className="search">
-                                    <InputGroup>
-                                        <Input value={searchText} onChange={handleChange} />
-                                        <InputGroupAddon addonType="append">
-                                            <Button color="secondary" onClick={handleSearch}><i className="fas fa-search"></i></Button>
-                                        </InputGroupAddon>
-                                    </InputGroup>
-                                </div>
-                            </Col>
-                        </Row>
-                        <Row>
-                            <Col>
-                                <Button color="link" onClick={handleRelease}>Reset search</Button>
-                            </Col>
-                            <Col>
-                                <Button outline color="secondary float-right" onClick={handleSplit} id="12"><i className="fas fa-list"></i></Button>
-                                <Button outline color="secondary float-right" onClick={handleSplit} id="6"><i className="fas fa-table"></i></Button>
-                            </Col>
-                        </Row>
-                        <Row>
-                            <Col>
-                                <div className="content">
-                                    <Row>
-                                        {content.item.map((val, idx) => {
+            <Container>
+                <MainContent>
+                    <Row>
+                        <Col>
+                            <div className="search">
+                                <InputGroup>
+                                    <Input value={searchText} onChange={handleChange} />
+                                </InputGroup>
+                            </div>
+                        </Col>
+                    </Row>
+                    <Row>
+                        <Col>
+                            <Button color="link" onClick={handleRelease}>Reset search</Button>
+                        </Col>
+                        <Col>
+                            <Button outline color="secondary float-right" onClick={handleSplit} id="12"><i className="fas fa-list"></i></Button>
+                            <Button outline color="secondary float-right" onClick={handleSplit} id="6"><i className="fas fa-table"></i></Button>
+                        </Col>
+                    </Row>
+                    <Row>
+                        <Col>
+                            <div className="content">
+                                <Row>
+                                    {props.content.item.map((val, idx) => {
+                                        if (val.name.indexOf(searchText) > -1) {
                                             return <Col xs={split} key={idx}>
                                                 <div key={idx}>
                                                     <ChallengeCard>
@@ -119,29 +101,29 @@ function Cancel(props) {
                                                             </TopList>
                                                             <List type="inline">
                                                                 <ListInlineLabel>State</ListInlineLabel>
-                                                                <ListInlineItem><Badge color="warning">{val.state}</Badge></ListInlineItem>
+                                                                <ListInlineItem><Badge color="warning">{val.status}</Badge></ListInlineItem>
                                                             </List>
                                                             <Button color="danger" onClick={toggle} value={val.id}>Run cancel</Button>
                                                         </ChallengeCardBody>
                                                     </ChallengeCard>
                                                 </div>
                                             </Col>
-                                        })}
-                                        {content.item.length === 0 && "Item does not exist"}
-                                    </Row>
-                                </div>
-                            </Col>
-                        </Row>
-                    </MainContent>
-                </Container>
-            }
+                                        }
+                                    })}
+                                    {props.content.item.length === 0 && "Item does not exist"}
+                                </Row>
+                            </div>
+                        </Col>
+                    </Row>
+                </MainContent>
+            </Container>
             <Modal isOpen={modalToggle} toggle={toggle} >
                 <ModalBody>
                     Are you sure you want to run cancel?
                 </ModalBody>
                 <ModalFooter>
-                    <Button color="primary" onClick={handleExecution}>OK</Button>{' '}
-                    <Button color="secondary" onClick={toggle}>Cancel</Button>
+                    <Button color="primary" onClick={handleExecution} disabled={isLoading} >{isLoading ? <Spinner color="secondary" /> : "OK"}</Button>{' '}
+                    <Button color="secondary" onClick={toggle} disabled={isLoading} >Cancel</Button>
                 </ModalFooter>
             </Modal>
         </div>

--- a/gui/src/containers/Challange/cancel.js
+++ b/gui/src/containers/Challange/cancel.js
@@ -107,7 +107,7 @@ function Cancel(props) {
                                             </Col>
                                         }
                                     })}
-                                    {props.content.item.length === 0 && "Item does not exist"}
+                                    {props.content.item.length === 0 && <Col>Item does not exist</Col>}
                                 </Row>
                             </div>
                         </Col>

--- a/gui/src/containers/Challange/cancel.js
+++ b/gui/src/containers/Challange/cancel.js
@@ -41,9 +41,6 @@ function Cancel(props) {
         setSearchText(e.target.value);
     }
 
-    const handleSearch = () => {
-    }
-
     const handleRelease = () => {
         setSearchText('');
     }
@@ -70,7 +67,7 @@ function Cancel(props) {
                         <Col>
                             <div className="search">
                                 <InputGroup>
-                                    <Input value={searchText} onChange={handleChange} />
+                                    <Input value={searchText} onChange={handleChange} placeholder="Search for token title..."/>
                                 </InputGroup>
                             </div>
                         </Col>

--- a/gui/src/containers/Challange/execution.js
+++ b/gui/src/containers/Challange/execution.js
@@ -120,7 +120,7 @@ function Execution(props) {
                                             }
                                         }
                                     })}
-                                    {props.accountInfo.tokens.length === 0 && "Item does not exist"}
+                                    {props.accountInfo.tokens.length === 0 && <Col>Item does not exist</Col>}
                                 </Row>
                             </div>
                         </Col>

--- a/gui/src/containers/Challange/execution.js
+++ b/gui/src/containers/Challange/execution.js
@@ -21,8 +21,6 @@ import '..//default.css';
 
 function Execution(props) {
     const { ipcRenderer } = window;
-    const [defaultContent, setDefaultContent] = useState([]);
-    const [content, setContent] = useState([]);
     const [isLoading, setIsLoading] = useState(false);
     const [searchText, setSearchText] = useState('');
     const [modalToggle, setModalToggle] = useState(false);
@@ -30,19 +28,6 @@ function Execution(props) {
     const [split, setSplit] = useState('12');
 
     useEffect(() => {
-        //find token info
-        const possessions = [];
-        for (const val of props.accountInfo.tokens) {
-            console.log(val)
-            for (const token of props.tokenList.item) {
-                if (val.addr === token.addr) {
-                    token.left = val.quantity;
-                    possessions.push(token);
-                }
-            }
-        }
-        setContent(possessions);
-        setDefaultContent(possessions);
         return () => console.log('unmounting...');
     }, [])
     const toggle = (e) => {
@@ -54,16 +39,8 @@ function Execution(props) {
         setSearchText(e.target.value);
     }
 
-    const handleSearch = () => {
-        const retValue = defaultContent.filter((val) => {
-            return val.name.indexOf(searchText) !== -1;
-        });
-        setContent(retValue);
-    }
-
     const handleRelease = () => {
         setSearchText('');
-        setContent(defaultContent);
     }
 
     const handleExecution = () => {
@@ -72,6 +49,8 @@ function Execution(props) {
         ipcRenderer.once('success-challange-start', async (event, arg) => {
             console.log(arg);
             console.log("success-challange-start")
+            await new Promise(resolve => setTimeout(resolve, 2000))
+            await props.refreshInfo();
             setIsLoading(false);
             setModalToggle(!modalToggle);
         });
@@ -95,10 +74,7 @@ function Execution(props) {
                         <Col>
                             <div className="search">
                                 <InputGroup>
-                                    <Input value={searchText} onChange={handleChange} />
-                                    <InputGroupAddon addonType="append">
-                                        <Button color="secondary" onClick={handleSearch}><i className="fas fa-search"></i></Button>
-                                    </InputGroupAddon>
+                                    <Input value={searchText} onChange={handleChange} placeholder="Search for token title..." />
                                 </InputGroup>
                             </div>
                         </Col>
@@ -116,31 +92,35 @@ function Execution(props) {
                         <Col>
                             <div className="content">
                                 <Row>
-                                    {content.map((val, idx) => {
-                                        return <Col xs={split} key={idx}>
-                                            <div key={idx}>
-                                                <ChallengeCard>
-                                                    <ChallengeCardHeader><strong>{val.name}</strong></ChallengeCardHeader>
-                                                    <ChallengeCardBody>
-                                                        <List type="inline">
-                                                            <ListInlineLabel>Remaining Token</ListInlineLabel>
-                                                            <ListInlineItem>{val.left}</ListInlineItem>
-                                                        </List>
-                                                        <TopList type="inline">
-                                                            <ListInlineLabel>Addr</ListInlineLabel>
-                                                            <ListInlineItem>{val.addr.length > 50 && split === "6" ? `${val.addr.slice(50)}...` : val.addr}</ListInlineItem>
-                                                        </TopList>
-                                                        <List type="inline">
-                                                            <ListInlineLabel>UUID</ListInlineLabel>
-                                                            <ListInlineItem>{val.uuid.length > 50 && split === "6" ? `${val.uuid.slice(50)}...` : val.uuid}</ListInlineItem>
-                                                        </List>
-                                                        <Button color="success" onClick={toggle} value={val.id}>Run challange</Button>
-                                                    </ChallengeCardBody>
-                                                </ChallengeCard>
-                                            </div>
-                                        </Col>
+                                    {props.accountInfo.tokens.map((token, idx) => {
+                                        for (let val of props.tokenList.item) {
+                                            if (token.addr === val.addr && val.name.indexOf(searchText) > -1) {
+                                                return <Col xs={split} key={idx}>
+                                                    <div key={idx}>
+                                                        <ChallengeCard>
+                                                            <ChallengeCardHeader><strong>{val.name}</strong></ChallengeCardHeader>
+                                                            <ChallengeCardBody>
+                                                                <List type="inline">
+                                                                    <ListInlineLabel>Remaining Token</ListInlineLabel>
+                                                                    <ListInlineItem>{token.quantity}</ListInlineItem>
+                                                                </List>
+                                                                <TopList type="inline">
+                                                                    <ListInlineLabel>Addr</ListInlineLabel>
+                                                                    <ListInlineItem>{val.addr.length > 50 && split === "6" ? `${val.addr.slice(50)}...` : val.addr}</ListInlineItem>
+                                                                </TopList>
+                                                                <List type="inline">
+                                                                    <ListInlineLabel>UUID</ListInlineLabel>
+                                                                    <ListInlineItem>{val.uuid.length > 50 && split === "6" ? `${val.uuid.slice(50)}...` : val.uuid}</ListInlineItem>
+                                                                </List>
+                                                                <Button color="success" onClick={toggle} value={val.id}>Run challange</Button>
+                                                            </ChallengeCardBody>
+                                                        </ChallengeCard>
+                                                    </div>
+                                                </Col>
+                                            }
+                                        }
                                     })}
-                                    {content.length === 0 && "Item does not exist"}
+                                    {props.accountInfo.tokens.length === 0 && "Item does not exist"}
                                 </Row>
                             </div>
                         </Col>

--- a/gui/src/containers/buycti.js
+++ b/gui/src/containers/buycti.js
@@ -20,7 +20,6 @@ import { Button, Card, CardBody, CardHeader, Col, Container, Input, InputGroup, 
 
 function BuyCti(props) {
     const { ipcRenderer } = window;
-    const [content, setContent] = useState(props.content);
     const [isLoading, setIsLoading] = useState(false);
     const [searchText, setSearchText] = useState('');
     const [modalToggle, setModalToggle] = useState(false);
@@ -40,16 +39,8 @@ function BuyCti(props) {
         setSearchText(e.target.value);
     }
 
-    const handleSearch = () => {
-        const retValue = props.content.item.filter((val) => {
-            return val.name.indexOf(searchText) !== -1;
-        });
-        setContent({ item: retValue });
-    }
-
     const handleRelease = () => {
         setSearchText('');
-        setContent(props.content);
     }
 
     const handleBuy = (e) => {
@@ -57,7 +48,7 @@ function BuyCti(props) {
         ipcRenderer.send('buy', targetId);
         ipcRenderer.once('success-buy', async (event, arg) => {
             console.log(arg);
-            await Promise.all(props.getInfo());
+            await props.refreshInfo();
             setIsLoading(false);
             setModalToggle(!modalToggle);
         });
@@ -75,10 +66,7 @@ function BuyCti(props) {
                         <Col>
                             <div className="search">
                                 <InputGroup>
-                                    <Input value={searchText} onChange={handleChange} />
-                                    <InputGroupAddon addonType="append">
-                                        <Button color="secondary" onClick={handleSearch}><i className="fas fa-search"></i></Button>
-                                    </InputGroupAddon>
+                                    <Input value={searchText} onChange={handleChange} placeholder="Search for token title..." />
                                 </InputGroup>
                             </div>
                         </Col>
@@ -96,37 +84,39 @@ function BuyCti(props) {
                         <Col>
                             <div className="content">
                                 <Row>
-                                    {content.item.map((val, idx) => {
-                                        return <Col xs={split} key={idx}>
-                                            <BuyCard>
-                                                <CardHeader style={{ backgroundColor: "#bbe2f1" }}><strong>{val.name}</strong></CardHeader>
-                                                <BuyCardBody>
-                                                    <TopList type="inline">
-                                                        <ListInlineLabel>Price</ListInlineLabel>
-                                                        <ListInlineItem style={{ fontSize: "36px" }}>{val.price}</ListInlineItem>
-                                                        <ListInlineLabel>pts</ListInlineLabel>
-                                                    </TopList>
-                                                    <List type="inline">
-                                                        <ListInlineLabel>Remaining Token</ListInlineLabel>
-                                                        <ListInlineItem>{val.left}</ListInlineItem>
-                                                    </List>
-                                                    <TopList type="inline">
-                                                        <ListInlineLabel>Addr</ListInlineLabel>
-                                                        <ListInlineItem>{val.addr.length > 50 && split === "6" ? `${val.addr.slice(50)}...` : val.addr}</ListInlineItem>
-                                                    </TopList>
-                                                    <List type="inline">
-                                                        <ListInlineLabel>UUID</ListInlineLabel>
-                                                        <ListInlineItem>{val.uuid.length > 50 && split === "6" ? `${val.uuid.slice(50)}...` : val.uuid}</ListInlineItem>
-                                                    </List>
-                                                    <div>
-                                                        {val.quantity !== '' && `You have ${val.quantity}`}
-                                                    </div>
-                                                    <Button color="primary" onClick={toggle} value={val.id}>Buy</Button>
-                                                </BuyCardBody>
-                                            </BuyCard>
-                                        </Col>
+                                    {props.content.item.map((val, idx) => {
+                                        if (val.name.indexOf(searchText) > -1) {
+                                            return <Col xs={split} key={idx}>
+                                                <BuyCard>
+                                                    <CardHeader style={{ backgroundColor: "#bbe2f1" }}><strong>{val.name}</strong></CardHeader>
+                                                    <BuyCardBody>
+                                                        <TopList type="inline">
+                                                            <ListInlineLabel>Price</ListInlineLabel>
+                                                            <ListInlineItem style={{ fontSize: "36px" }}>{val.price}</ListInlineItem>
+                                                            <ListInlineLabel>pts</ListInlineLabel>
+                                                        </TopList>
+                                                        <List type="inline">
+                                                            <ListInlineLabel>Remaining Token</ListInlineLabel>
+                                                            <ListInlineItem>{val.left}</ListInlineItem>
+                                                        </List>
+                                                        <TopList type="inline">
+                                                            <ListInlineLabel>Addr</ListInlineLabel>
+                                                            <ListInlineItem>{val.addr.length > 50 && split === "6" ? `${val.addr.slice(50)}...` : val.addr}</ListInlineItem>
+                                                        </TopList>
+                                                        <List type="inline">
+                                                            <ListInlineLabel>UUID</ListInlineLabel>
+                                                            <ListInlineItem>{val.uuid.length > 50 && split === "6" ? `${val.uuid.slice(50)}...` : val.uuid}</ListInlineItem>
+                                                        </List>
+                                                        <div>
+                                                            {val.quantity !== '' && `You have ${val.quantity}`}
+                                                        </div>
+                                                        <Button color="primary" onClick={toggle} value={val.id}>Buy</Button>
+                                                    </BuyCardBody>
+                                                </BuyCard>
+                                            </Col>
+                                        }
                                     })}
-                                    {content.item.length === 0 && "Item does not exist"}
+                                    {props.content.item.length === 0 && "Item does not exist"}
                                 </Row>
                             </div>
                         </Col>

--- a/gui/src/containers/buycti.js
+++ b/gui/src/containers/buycti.js
@@ -116,7 +116,7 @@ function BuyCti(props) {
                                             </Col>
                                         }
                                     })}
-                                    {props.content.item.length === 0 && "Item does not exist"}
+                                    {props.content.item.length === 0 && <Col>Item does not exist</Col>}
                                 </Row>
                             </div>
                         </Col>

--- a/gui/src/containers/defaultLayout.js
+++ b/gui/src/containers/defaultLayout.js
@@ -155,8 +155,8 @@ function DefaultLayout(props) {
                                     <MainContent>
                                         <Switch>
                                             <Route path="/contents/account" name="account" render={() => <Account {...props} content={accountInfo} />} />
-                                            <Route path="/contents/buy" name="token-buy" render={() => <Buy {...props} content={tokenList} getInfo={getInfo} />} />
-                                            <Route path="/contents/challange/execution" name="challange-execution" render={() => <ChallangeExecution {...props} accountInfo={accountInfo} tokenList={tokenList} setChallangeResult={setChallangeResult} setToastOpen={setToastOpen} getInfo={getInfo} />} />
+                                            <Route path="/contents/buy" name="token-buy" render={() => <Buy {...props} content={tokenList} refreshInfo={refreshInfo} />} />
+                                            <Route path="/contents/challange/execution" name="challange-execution" render={() => <ChallangeExecution {...props} accountInfo={accountInfo} tokenList={tokenList} setChallangeResult={setChallangeResult} setToastOpen={setToastOpen} refreshInfo={refreshInfo} />} />
                                             <Route path="/contents/challange/cancel" name="challange-cancel" render={() => <ChallangeCancel {...props} content={challangeList} refreshInfo={refreshInfo}/>} />
                                             <Route path="/contents" name="account" render={() => <Account {...props} content={accountInfo} />} />
                                         </Switch>


### PR DESCRIPTION
* タスクキャンセル画面をmetemctlコマンドに対応させました。
* トークン購入、チャレンジ実行、チャレンジキャンセル実行後に表示される項目が最新の項目になるよう修正しました。
   * また、それに伴い各ページの検索機能を、ボタン押下で検索を実行する形式から、検索窓へ入力した文字で即時に検索を実行する方式へ変更しました。
* トークン購入、チャレンジ実行、チャレンジキャンセル時に、表示する項目が存在しない場合に出力する'Item does not exist'という文字列に表示ズレがあった為、修正しました。
* pty.spawnにてmetemctlコマンドを実行する際、bashで実行するように設定していた為修正しました。
