### PR TITLE
Topic/monitor with datetime

### DIFF
--- a/src/metemcyber/core/bc/monitor/slack_notifier.py
+++ b/src/metemcyber/core/bc/monitor/slack_notifier.py
@@ -29,7 +29,7 @@ from metemcyber.core.bc.monitor.tx_counter import parse_queries as parse_counter
 class SectionGenerator:
     def summary_to_sections(self, summary: dict, _args: Namespace, _options: dict) -> List[dict]:
         return [{
-            'fallback': str(self),
+            'fallback': self.__class__.__name__,
             'title': 'abstract generator',
             'text': str(summary),
         }]
@@ -204,6 +204,9 @@ def main(args: Namespace):
 OPTIONS: List[Tuple[str, str, dict]] = [
     ('-c', '--config', dict(action='store', required=True)),
     ('-t', '--testmode', dict(action='store_true', required=False)),
+    ('-d', '--date_format', dict(action='store', required=False)),
+    ('-s', '--start', dict(action='store', required=False)),
+    ('-e', '--end', dict(action='store', required=False)),
 ]
 
 ARGUMENTS: List[Tuple[str, dict]] = [

--- a/src/metemcyber/core/bc/monitor/slack_notifier.py
+++ b/src/metemcyber/core/bc/monitor/slack_notifier.py
@@ -17,6 +17,7 @@
 import argparse
 import json
 import sys
+from argparse import Namespace
 from typing import ClassVar, List, Tuple, Type
 
 import requests
@@ -26,7 +27,7 @@ from metemcyber.core.bc.monitor.tx_counter import parse_queries as parse_counter
 
 
 class SectionGenerator:
-    def summary_to_sections(self, summary: dict, _options: dict) -> List[dict]:
+    def summary_to_sections(self, summary: dict, _args: Namespace, _options: dict) -> List[dict]:
         return [{
             'fallback': str(self),
             'title': 'abstract generator',
@@ -107,7 +108,7 @@ class Waixu(SectionGenerator):
 
         return waipu, text
 
-    def summary_to_sections(self, summary: dict, _options: dict) -> List[dict]:
+    def summary_to_sections(self, summary: dict, _args: Namespace, _options: dict) -> List[dict]:
         waicu, waicu_text = self._calc_waicu(summary)
         waipu, waipu_text = self._calc_waipu(summary)
 
@@ -188,15 +189,15 @@ def parse_queries(queries: List[dict]) -> List[
     return ret
 
 
-def main(args):
+def main(args: Namespace):
     notifier = SlackNotifier(args.config, testmode=args.testmode)
     with open(args.config, 'r') as fin:
         queries = [q for q in json.load(fin).get('queries', []) if not q.get('disable')]
     for gclass, cclass, options in parse_queries(queries):
         generator = gclass()
-        counter = cclass(args.config, options)
-        summary = counter.summarize(options)
-        notifier.add_sections(generator.summary_to_sections(summary, options))
+        counter = cclass(args, options)
+        summary = counter.summarize(args, options)
+        notifier.add_sections(generator.summary_to_sections(summary, args, options))
     notifier.send_query()
 
 

--- a/src/metemcyber/core/bc/monitor/tx_counter.py
+++ b/src/metemcyber/core/bc/monitor/tx_counter.py
@@ -94,13 +94,6 @@ class TransactionCounter:
                     else:
                         raise Exception(f'Invalid filter: {key}')
 
-    def fix_startblock(self) -> int:
-        tmp = int(self.conf.get('start_block', 1))
-        if tmp > 0:
-            return tmp
-        tmp += self.dec_db.latest
-        return tmp if tmp > 0 else 1
-
     def get_blocks(self, days: int = 0, hours: int = 0) -> List[int]:
         assert days >= 0 and hours >= 0
         border = -1

--- a/src/metemcyber/core/bc/monitor/tx_decoder.py
+++ b/src/metemcyber/core/bc/monitor/tx_decoder.py
@@ -68,7 +68,7 @@ class ABIManager:
             return tx0
 
         if not to_addr:  # maybe deploy
-            contract_address = tx0['x_tx_receipt'].get('contractAddress')
+            contract_address = tx0['x_tx_receipt'].contractAddress
             if contract_address:
                 tx0['deployed_address'] = contract_address
                 tx0['function'] = '(deploy)'
@@ -127,11 +127,9 @@ class TransactionDecoder:
         return tmp if tmp > 0 else 1
 
     def simplify_tx(self, tx0: dict) -> dict:
-        skip_keys = {'blockHash', 'hash', 'nonce', 'r', 's', 'v', 'x_tx_receipt'}
+        skip_keys = {'blockHash', 'hash', 'nonce', 'r', 's', 'v', 'x_tx_receipt', 'x_block'}
         skip_keys_on_zero = {'to', 'input', 'value'}
-        status = tx0.get('x_tx_receipt', {}).get('status')
-        if status is not None:
-            tx0['x_receipt_status'] = status
+        tx0['x_receipt_status'] = tx0['x_tx_receipt'].status
         if tx0.get('input'):
             tx0 = self.abi_mgr.decode(tx0)
         for key in skip_keys:

--- a/tx_monitor.conf.tmpl
+++ b/tx_monitor.conf.tmpl
@@ -37,8 +37,9 @@
                     "include_brokers": [],
                     "exclude_brokers": []
                 },
-                "days": 7,
-                "hours": 0}},
+                "date_format": "%Y-%m-%dT%H:%M:%S",
+                "start": "2021-04-01T09:00:00",
+                "end":   "2021-08-01T09:00:00"}},
         {
             "class": "Simple",
             "disable": 1,
@@ -49,7 +50,9 @@
                     "include_from": [],
                     "exclude_from": []
                 },
-                "days": 7,
+                "date_format": "%c",
+                "start": "Sun Apr 01 09:00:00 2021",
+                "end":   "Sun Aug 01 09:00:00 2021",
                 "reverted": "yes"}}
     ]
 }


### PR DESCRIPTION
トランザクションモニタの収集範囲を、期間でなく開始＆終了の日時で指定するように改修しました。
- raw data 収集時に block の timestamp も記録しておき、指定範囲のブロックを抽出する仕組みです。
- 日時はコマンドラインオプションの指定が最優先で、オプション未指定なら設定ファイルを参照し、設定ファイルも未設定ならデフォルト（Epoch と now）を適用します。
- 日時指定のフォーマットに迷ったので、フォーマット自体を指定できるようにしました。デフォルトは ISO 8601 形式（%Y-%m-%dT%H:%M:%S）です。
