### PR TITLE
Fix/missing init

### DIFF
--- a/src/metemcyber/core/bc/monitor/tx_counter.py
+++ b/src/metemcyber/core/bc/monitor/tx_counter.py
@@ -117,6 +117,7 @@ class TransactionCounter:
         ret = []
         if btx.contract == '(Unknown)':
             if btx.method == '(deploy)':
+                assert btx.deployed
                 btx.contract = self.meta.get(btx.deployed).get('name', '(Unknown)')
             elif btx.addr_to:
                 btx.contract = self.meta.get(btx.addr_to).get('name') or (


### PR DESCRIPTION
monitor ディレクトリに __init__.py を入れ忘れており、mypy がちゃんと機能していなかったようなので対応しました。