### PR TITLE
Topic/tx counter service

### DIFF
--- a/src/metemcyber/core/bc/monitor/tx_counter.py
+++ b/src/metemcyber/core/bc/monitor/tx_counter.py
@@ -239,6 +239,12 @@ class DailyActivity(TransactionCounter):
             return []
         return [[str(self._ts2offset(tx0['x_timestamp']))]]
 
+    def summarize(self, args: Namespace, opt: dict) -> dict:
+        result = super().summarize(args, opt)
+        return {'activities': [
+            {'days-offset': int(key), 'count': value} for key, value in result.items()
+        ]}
+
 
 def str2counter(classname: str) -> Type[TransactionCounter]:
     counter_class = (Waixu if classname == 'Waixu' else

--- a/src/metemcyber/core/bc/monitor/tx_counter_fastapi.py
+++ b/src/metemcyber/core/bc/monitor/tx_counter_fastapi.py
@@ -19,6 +19,7 @@ import os
 from argparse import Namespace
 from typing import List
 
+import uvicorn
 from fastapi import FastAPI
 
 from metemcyber.core.bc.monitor.tx_counter import ARGUMENTS, OPTIONS, str2counter
@@ -42,7 +43,7 @@ COUNTER_ARGS = _setup_counter_args()
 app = FastAPI()
 
 
-@app.post('/')
+@app.post('/tx_counter')
 async def post_receiver(queries: List[dict]) -> List[dict]:
     result = []
     for query in queries:
@@ -50,3 +51,7 @@ async def post_receiver(queries: List[dict]) -> List[dict]:
         counter = str2counter(query['class'])(COUNTER_ARGS, options)
         result.append(counter.summarize(COUNTER_ARGS, options))
     return result
+
+
+if __name__ == '__main__':
+    uvicorn.run(app, port=38000, host='0.0.0.0')

--- a/src/metemcyber/core/bc/monitor/tx_counter_fastapi.py
+++ b/src/metemcyber/core/bc/monitor/tx_counter_fastapi.py
@@ -1,0 +1,52 @@
+#
+#    Copyright 2021, NTT Communications Corp.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+import argparse
+import os
+from argparse import Namespace
+from typing import List
+
+from fastapi import FastAPI
+
+from metemcyber.core.bc.monitor.tx_counter import ARGUMENTS, OPTIONS, str2counter
+
+
+def _setup_counter_args() -> Namespace:
+    config_path = os.environ.get('TX_MONITOR_CONFIG_PATH')
+    if not config_path:
+        raise Exception('Missing environment variable: TX_MONITOR_CONFIG_PATH')
+    parser = argparse.ArgumentParser()
+    for sname, lname, opts in OPTIONS:
+        parser.add_argument(sname, lname, **opts)
+    for name, opts in ARGUMENTS:
+        parser.add_argument(name, **opts)
+    args_array = ['-c', config_path]
+    return parser.parse_args(args=args_array)
+
+
+os.environ['TZ'] = 'UTC'
+COUNTER_ARGS = _setup_counter_args()
+app = FastAPI()
+
+
+@app.post('/')
+async def post_receiver(queries: List[dict]) -> List[dict]:
+    result = []
+    for query in queries:
+        options = query.get('options', {})
+        counter = str2counter(query['class'])(COUNTER_ARGS, options)
+        result.append(counter.summarize(COUNTER_ARGS, options))
+    return result

--- a/src/metemcyber/core/bc/monitor/tx_db.py
+++ b/src/metemcyber/core/bc/monitor/tx_db.py
@@ -79,7 +79,7 @@ class TransactionDB:
         return sorted([int(key) for key in list(shelf.keys())
                        if key.isdecimal() and
                           (minimum is None or int(key) >= minimum) and
-                          (maximum is None or int(key) <= maximum)])
+                          (maximum is None or int(key) < maximum)])
 
     def get(self, *args, **kwargs):
         return self._shelf_wrapper(True, self._get, *args, **kwargs)

--- a/src/metemcyber/core/bc/monitor/tx_decoder.py
+++ b/src/metemcyber/core/bc/monitor/tx_decoder.py
@@ -38,7 +38,7 @@ def get_blocks_by_timestamp(
         raise Exception('Wrong type of database. (should be a decoded database)')
     return [block for block, timestamp in tdb.get('timestamps').items()
             if (min_timestamp <= 0 or timestamp >= min_timestamp) and
-               (max_timestamp <= 0 or timestamp <= max_timestamp)
+               (max_timestamp <= 0 or timestamp < max_timestamp)
             ]
 
 

--- a/tx_monitor.conf.tmpl
+++ b/tx_monitor.conf.tmpl
@@ -53,6 +53,9 @@
                 "date_format": "%c",
                 "start": "Sun Apr 01 09:00:00 2021",
                 "end":   "Sun Aug 01 09:00:00 2021",
+                "another_format_sample": {
+                    "date_format": "%Y-%m-%d %H:%M:%S %z",
+                    "start": "2021-01-01 12:34:56 +0900"},
                 "reverted": "yes"}}
     ]
 }


### PR DESCRIPTION
トランザクションモニタの tx_counter の WebService 版（の暫定版）です。

required: pip install fastapi uvicorn
environ: PYTHONPATH=/path/to/src TX_MONITOR_CONFIG_PATH=/path/to/config
usage: python3 src/metemcyber/core/bc/monitor/tx_counter_fastapi.py
or  uvicorn metemcyber.core.bc.monitor.tx_counter_fastapi:app --reload

- tx_counter.py で -c オプションで指定する config filepath を、環境変数 TX_MONITOR_CONFIG_PATH で指定します（uvicorn 経由で実行した場合にオプション指定できないための処置）。config の中身は tx_counter.py と共通です。
- tx_counter_fastapi.py を直接実行した場合のHTTP Listen Port は暫定的に 38000 固定にしてあります。uvicorn 利用時は uvicorn --help 参照。
- I/F の URL Path は /tx_counter です。これは後で変更する予定です。
- 投入する POST データは CLI での tx_counter に投入する queries そのものです。
- Timezone は UTC です。start, end を指定する際に留意してください。

現在は調整しやすさを優先した実装のためフレキシブル、見方を替えると不明瞭で分かりにくいです。orz
仕様が固まってきたらデータ構造なども固定化する予定です。