### PR TITLE
Topic/shared solver

### DIFF
--- a/src/metemcyber/cli/cli.py
+++ b/src/metemcyber/cli/cli.py
@@ -1413,8 +1413,10 @@ def _assetclient_post(ctx, token, filepath, support):
     account = _load_account(ctx)
     flx = FlexibleIndexToken(ctx, token)
     _authorize_eoaa(ctx, flx.address, info['solver_address'])
-    _load_assetclient(ctx).post_asset(account, flx.address, filepath, support)
+    result = _load_assetclient(ctx).post_asset(account, flx.address, filepath, support)
     typer.echo(f'uploaded asset file for token: {flx.address}.')
+    if result != 'ok':
+        typer.echo(f'CAUTION: {result}')
 
 
 @assetclient_app.command('remove',
@@ -1430,8 +1432,10 @@ def _assetclient_delete(ctx, token):
     account = _load_account(ctx)
     flx = FlexibleIndexToken(ctx, token)
     _authorize_eoaa(ctx, flx.address, solver_eoaa)
-    _load_assetclient(ctx).delete_asset(account, flx.address)
+    result = _load_assetclient(ctx).delete_asset(account, flx.address)
     typer.echo(f'removed asset file for token: {flx.address}.')
+    if result != 'ok':
+        typer.echo(f'CAUTION: {result}')
     _revoke_eoaa(ctx, flx.address, solver_eoaa)
 
 

--- a/src/metemcyber/core/asset_manager.py
+++ b/src/metemcyber/core/asset_manager.py
@@ -324,7 +324,7 @@ class AssetManagerClient:
         return jdata
 
     def post_asset(self, account: Account, token_address: ChecksumAddress, filepath: str,
-                   auto_support: bool = False):
+                   auto_support: bool = False) -> str:
         url = f'{self.base_url}/{URLPATH_MISP}'
         request_data = PostMispRequest(timestamp=int(datetime.now().timestamp()),
                                        token_address=token_address,
@@ -338,10 +338,11 @@ class AssetManagerClient:
         headers = {'Content-Type': 'application/json'}
         jdata = request_data.json().encode('utf-8')
         request = Request(url, method='POST', headers=headers, data=jdata)
-        with urlopen(request) as _response:
-            pass
+        with urlopen(request) as response:
+            detail = json.loads(response.read().decode())['result']
+            return detail
 
-    def delete_asset(self, account: Account, token_address: ChecksumAddress):
+    def delete_asset(self, account: Account, token_address: ChecksumAddress) -> str:
         url = f'{self.base_url}/{URLPATH_MISP}'
         request_data = DeleteMispRequest(timestamp=int(datetime.now().timestamp()),
                                          token_address=token_address,
@@ -352,5 +353,6 @@ class AssetManagerClient:
         headers = {'Content-Type': 'application/json'}
         jdata = request_data.json().encode('utf-8')
         request = Request(url, method='DELETE', headers=headers, data=jdata)
-        with urlopen(request) as _response:
-            pass
+        with urlopen(request) as response:
+            detail = json.loads(response.read().decode())['result']
+            return detail

--- a/src/metemcyber/core/asset_manager.py
+++ b/src/metemcyber/core/asset_manager.py
@@ -27,6 +27,7 @@ import uvicorn
 from eth_typing import ChecksumAddress
 from fastapi import FastAPI, HTTPException
 from psutil import Process
+# pylint: disable=no-name-in-module
 from pydantic import BaseModel
 from web3 import Web3
 

--- a/src/metemcyber/core/asset_manager.py
+++ b/src/metemcyber/core/asset_manager.py
@@ -46,6 +46,7 @@ CLIENTLOG = get_logger(name='asset_client', file_prefix='core')
 
 URLPATH_INFO = 'info'
 URLPATH_MISP = 'misp_object'
+URLPATH_SOLVER = 'solver'
 
 CONFIG_SECTION = 'asset_manager'
 DEFAULT_CONFIGS = {
@@ -117,6 +118,9 @@ class AssetManager:
         self.app.get(f'/{URLPATH_INFO}')(self._get_info)
         self.app.post(f'/{URLPATH_MISP}')(self._post_asset)
         self.app.delete(f'/{URLPATH_MISP}')(self._delete_asset)
+        # self.app.get(f'/{URLPATH_SOLVER}')(self._get_accepting)
+        # self.app.post(f'/{URLPATH_SOLVER}')(self._post_accepting)
+        # self.app.delete(f'/{URLPATH_SOLVER}')(self._delete_accepting)
 
     def _get_solver(self) -> MCSClient:  # CAUTION: do not cache client.
         solver = MCSClient(self.solver_account, APP_DIR)
@@ -158,7 +162,7 @@ class AssetManager:
                                 'the request time and the current time is too large')
         try:
             signer = request.signer
-            SERVERLOG.DEBUG(f'signer: {signer}')
+            SERVERLOG.debug(f'signer: {signer}')
         except Exception as err:
             raise HTTPException(400, f'Wrong Signature: {err}') from err
         try:

--- a/src/metemcyber/core/asset_manager.py
+++ b/src/metemcyber/core/asset_manager.py
@@ -1,0 +1,280 @@
+#
+#    Copyright 2021, NTT Communications Corp.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+import os
+import sys
+from datetime import datetime
+from signal import SIGINT
+from time import sleep
+from typing import List, Tuple
+
+import uvicorn
+from eth_typing import ChecksumAddress
+from fastapi import FastAPI, HTTPException
+from psutil import Process
+from pydantic import BaseModel
+from web3 import Web3
+
+from metemcyber.cli.constants import APP_DIR
+from metemcyber.core.bc.account import Account
+from metemcyber.core.bc.cti_token import CTIToken
+from metemcyber.core.bc.ether import Ether
+from metemcyber.core.bc.util import sign_message, verify_message
+from metemcyber.core.logger import get_logger
+from metemcyber.core.multi_solver import MCSClient, MCSErrno, MCSError
+
+#CTX: typer.Context = typer.Context(Command('_fake_command_'))
+PIDFILEPATH = f'{APP_DIR}/assetmgr.pid'
+VALID_TIMESTAMP_RANGE = 12 * 3600  # 12 hours in sec
+LOGGER = get_logger(name='asset_mgr', file_prefix='core')
+
+CONFIG_SECTION = 'asset_manager'
+DEFAULT_CONFIGS = {
+    CONFIG_SECTION: {
+        'listen_address': '0.0.0.0',
+        'listen_port': '48000',
+    }
+}
+
+
+class SignedRequest(BaseModel):
+    timestamp: int
+    data: str
+    signature: str  # should be sign_message(str(timestamp) + data, private_key)
+
+    @property
+    def string_to_sign(self) -> str:
+        return str(self.timestamp) + self.data
+
+    @property
+    def signer(self) -> ChecksumAddress:
+        return verify_message(self.string_to_sign, self.signature)
+
+    def gen_signature(self, private_key) -> str:
+        return sign_message(self.string_to_sign, private_key)
+
+
+class RequestWithTokenAddress(SignedRequest):
+    token_address: ChecksumAddress
+
+
+class PutMispRequest(RequestWithTokenAddress):
+    auto_support: bool = False
+
+
+class DeleteMispRequest(RequestWithTokenAddress):
+    pass
+
+
+class AssetManager:
+    listen_address: str
+    listen_port: int
+    anonymous: Account
+    solver_account: Account
+    operator_address: ChecksumAddress
+    assets_rootpath: str
+    app: FastAPI
+
+    def __init__(self,
+                 listen_address: str,
+                 listen_port: int,
+                 endpoint_url: str,
+                 solver_account: Account,
+                 operator_address: ChecksumAddress,
+                 assets_rootpath: str):
+        self.listen_address = listen_address
+        self.listen_port = listen_port
+        self.anonymous = Account(Ether(endpoint_url))
+        self.solver_account = solver_account
+        self.operator_address = operator_address
+        self.assets_rootpath = assets_rootpath
+        try:
+            self._get_solver()
+        except Exception as err:
+            raise Exception(f'Solver must be running and enabled: {err}') from err
+
+        self.app = FastAPI()
+        self.app.get('/info')(self._get_info)
+        self.app.put('/misp_object')(self._put_asset)
+        self.app.delete('/misp_object')(self._delete_asset)
+
+    def _get_solver(self) -> MCSClient:  # CAUTION: do not cache client.
+        solver = MCSClient(self.solver_account, APP_DIR)
+        solver.connect()
+        solver.login()
+        try:
+            addr = solver.get_solver()
+        except MCSError as err:
+            if err.code == MCSErrno.ENOENT:
+                msg = f'Solver is running, but not yet enabled'
+            else:
+                msg = str(err)
+            raise Exception(msg) from err
+        if addr != self.operator_address:
+            raise Exception(
+                f'Solver is running with different operator({addr}) '
+                f'from configured({self.operator_address})')
+        return solver
+
+    async def _get_info(self) -> dict:
+        try:
+            self._get_solver()
+            solver_status = 'running'
+        except Exception as err:
+            solver_status = str(err)
+        return {
+            'solver_address': self.solver_account.eoa,
+            'operator_address': self.operator_address,
+            'solver_status': solver_status,
+        }
+
+    def _check_signed_request(self, request: RequestWithTokenAddress):
+        print(request)
+        ts_now = int(datetime.now().timestamp())
+        ts_diff = abs(ts_now - request.timestamp)
+        if ts_diff > VALID_TIMESTAMP_RANGE:
+            raise HTTPException(400,
+                                'RequestTimeTooSkewed: The difference between '
+                                'the request time and the current time is too large')
+        try:
+            signer = request.signer
+            print(f'Signer: {signer}')
+        except Exception as err:
+            raise HTTPException(400, f'Wrong Signature: {err}') from err
+        try:
+            cti_token = CTIToken(self.anonymous).get(request.token_address)
+            print(f'Token owner: {cti_token.publisher}')
+        except Exception as err:
+            raise HTTPException(400, f'Invalid token address: {err}') from err
+        if signer != cti_token.publisher:
+            raise HTTPException(400, 'Not a token publisher')
+        if not cti_token.is_operator(self.solver_account.eoa, signer):
+            raise HTTPException(400, 'Solver is not authorized')
+        # TODO
+        # apply whitelist and/or blacklist for access control
+
+    def _asset_filepath(self, token_address: ChecksumAddress) -> str:
+        assert Web3.isChecksumAddress(token_address)
+        return f'{self.assets_rootpath}/{token_address}'
+
+    async def _put_asset(self, request: PutMispRequest) -> dict:
+        self._check_signed_request(request)
+        try:
+            filepath = self._asset_filepath(request.token_address)
+            if os.path.exists(filepath):
+                os.unlink(filepath)  # for the case target already exists as a symlink.
+            with open(filepath, 'w') as fout:
+                fout.write(request.data)
+        except Exception as err:
+            raise HTTPException(500, f'{err.__class__.__name__}: {err}') from err
+        if request.auto_support:
+            try:
+                self._get_solver().solver('accept_challenges', [request.token_address])
+            except Exception as err:
+                return {
+                    'result': f'uploading file succeeded, but solver control failed: {err}'}
+        return {'result': 'ok'}
+
+    async def _delete_asset(self, request: DeleteMispRequest) -> dict:
+        self._check_signed_request(request)
+        filepath = self._asset_filepath(request.token_address)
+        try:
+            if os.path.exists(filepath):
+                os.unlink(filepath)
+        except Exception as err:
+            raise HTTPException(500, f'{err.__class__.__name__}: str(err)') from err
+        try:
+            self._get_solver().solver('refuse_challenges', [request.token_address])
+        except Exception as err:
+            return {
+                'result': f'removing file succeeded, but solver control failed: {err}'}
+        return {'result': 'ok'}
+
+    def run(self):
+        uvicorn.run(self.app, host=self.listen_address, port=self.listen_port, log_level='trace')
+
+
+class AssetManagerController:
+    def __init__(self):
+        self.expected_cmd_args = ['asset_manager', 'start']
+        self.pid, self.listen_address, self.listen_port = self.get_running_params()
+
+    def get_running_params(self) -> Tuple[int, str, int]:  # pid, addr, port
+        try:
+            with open(PIDFILEPATH, 'r') as fin:
+                str_data = fin.readline().strip()
+            str_pid, str_addr, str_port = str_data.split('\t', 2)
+        except Exception:
+            return 0, '', 0
+        try:
+            proc = Process(int(str_pid))
+            cmdline: List = proc.cmdline()
+            if len(cmdline) - 2 == len(self.expected_cmd_args):  # cut leading 'python'&'metemctl'
+                for idx, arg in enumerate(self.expected_cmd_args):
+                    assert cmdline[2 + idx] == arg
+                return int(str_pid), str_addr, int(str_port)
+        except Exception:
+            pass
+        if os.path.exists(PIDFILEPATH):
+            os.unlink(PIDFILEPATH)  # remove defunct pidfile.
+        return 0, '', 0
+
+    def start(self,
+              listen_address: str,
+              listen_port: int,
+              endpoint_url: str,
+              solver_account: Account,
+              operator_address: ChecksumAddress,
+              assets_rootpath: str) -> int:
+        if self.pid > 0:
+            raise Exception(f'Already running on pid: {self.pid}')
+
+        pid = os.fork()
+        if pid > 0:  # parent
+            for _cnt in range(3):
+                sleep(1)
+                if self.get_running_params()[0] != pid:
+                    continue  # wait again
+                return pid
+            raise Exception('Cannot start AssetManager')
+
+        # child
+        try:
+            mgr = AssetManager(listen_address,
+                               listen_port,
+                               endpoint_url,
+                               solver_account,
+                               operator_address,
+                               assets_rootpath)
+            with open(PIDFILEPATH, 'w') as fout:
+                fout.write(f'{os.getpid()}\t{listen_address}\t{listen_port}\n')
+            mgr.run()
+        except KeyboardInterrupt:
+            pass
+        finally:
+            if os.path.exists(PIDFILEPATH):
+                os.unlink(PIDFILEPATH)
+        sys.exit(0)
+        return 0  # not reached
+
+    def stop(self):
+        if self.pid <= 0:
+            raise Exception('Not running')
+        try:
+            os.kill(self.pid, SIGINT)
+            self.pid = 0
+        except Exception as err:
+            raise Exception(f'Cannot stop AssetManager(pid={self.pid})') from err

--- a/src/metemcyber/plugins/gcs_solver.py
+++ b/src/metemcyber/plugins/gcs_solver.py
@@ -23,7 +23,6 @@ import requests
 from eth_typing import ChecksumAddress
 from web3 import Web3
 
-from metemcyber.cli.constants import APP_DIR
 from metemcyber.core.bc.account import Account
 from metemcyber.core.logger import get_logger
 from metemcyber.core.solver import BaseSolver
@@ -34,12 +33,10 @@ LOGGER = get_logger(name='gcs_solver', file_prefix='core')
 CONFIG_SECTION = 'gcs_solver'
 DEFAULT_CONFIGS = {
     CONFIG_SECTION: {
-        'assets_path': f'{APP_DIR}/workspace/upload',
         'functions_url': 'https://exchange.metemcyber.ntt.com',
         'functions_token': 'YOUR_TOKEN_TO_UPLOAD_GCS',
     }
 }
-# Note: assets_path should be same with "{general.workspace}/upload".
 
 
 class Solver(BaseSolver):
@@ -95,8 +92,8 @@ class Solver(BaseSolver):
             LOGGER.info('finished task %s', task_id)
 
     def upload_to_storage(self, cti_address):
-        file_path = os.path.abspath('{}/{}'.format(
-            self.config.get(CONFIG_SECTION, 'assets_path'), cti_address))
+        file_path = os.path.abspath(
+            f"{self.config['general']['workspace']}/upload/{cti_address}")
         url = self.uploader.upload_file(file_path)
         return url
 

--- a/src/metemcyber/plugins/standalone_solver.py
+++ b/src/metemcyber/plugins/standalone_solver.py
@@ -22,7 +22,6 @@ from typing import ClassVar, Optional
 from eth_typing import ChecksumAddress
 from web3 import Web3
 
-from metemcyber.cli.constants import APP_DIR
 from metemcyber.core.bc.account import Account
 from metemcyber.core.logger import get_logger
 from metemcyber.core.solver import BaseSolver
@@ -37,10 +36,8 @@ CONFIG_SECTION = 'standalone_solver'
 DEFAULT_CONFIGS = {
     CONFIG_SECTION: {
         'listen_address': 'localhost',
-        'assets_path': f'{APP_DIR}/workspace/upload',
     }
 }
-# Note: assets_path should be same with "{general.workspace}/upload".
 
 
 class SimpleHandler(SimpleHTTPRequestHandler):
@@ -116,7 +113,7 @@ class Solver(BaseSolver):
         self.fileserver = LocalHttpServer(
             self.account.eoa,
             self.config[CONFIG_SECTION]['listen_address'],
-            self.config[CONFIG_SECTION]['assets_path'])
+            f"{self.config['general']['workspace']}/upload")
         self.fileserver.start()
 
     def destroy(self):


### PR DESCRIPTION
shared solver の叩き台を実装しました。諸般の事情により asset manager という名称になってます。
- コマンド名他諸々は仮称です。良さ気な名称募集中。
- solver が参照する asset file path を {workspace}/upload に固定しました。
- metemctl asset_manager でサービス制御。現在は start, stop, status が動作します。manager 起動時には solver が enable である必要があります。
- metemctl asset_client でリモートの asset manager にアクセスします。現在は info, upload, remove が動作します。upload には --support オプションがあり、自動的に solver support します。（個別に support, obsolete する機能は未対応です）
- config に asset_manager のセクションが増えてます。scheme, listen_address, listen_port の項があり、manager, client の両方（scheme は client のみ）が参照します。（client は素直に url で設定した方がよいかもしれません）
- ローカルで solver を稼働させつつリモートに upload することも可能です。どちらが accept するかは早い者勝ち。

publish への組み込みなどは現状未対応なので、追って実装します。