### PR TITLE
fix authorize typo in tx_metadata_manager.py

### DIFF
--- a/src/metemcyber/core/bc/monitor/tx_metadata_manager.py
+++ b/src/metemcyber/core/bc/monitor/tx_metadata_manager.py
@@ -104,7 +104,7 @@ class CTICatalog(Contract):
             self.version = max(self.version, 1)
             if func == 'setMembers':
                 self.meta['members'] = tx0['input']['members_']
-        elif func in {'setPrivate', 'setPublic', 'authrizeUser', 'revokeUser'}:
+        elif func in {'setPrivate', 'setPublic', 'authorizeUser', 'revokeUser'}:
             self.version = 0
         elif func in {'registerCti', 'modifyCti'}:
             token_address = tx0['input']['tokenURI']


### PR DESCRIPTION
`authrize` を `authorize` に修正