### PR TITLE
fix standalone typo in standalone_solver.py

### DIFF
--- a/src/metemcyber/plugins/standalone_solver.py
+++ b/src/metemcyber/plugins/standalone_solver.py
@@ -27,7 +27,7 @@ from metemcyber.core.logger import get_logger
 from metemcyber.core.solver import BaseSolver
 from metemcyber.core.util import get_random_local_port, merge_config
 
-LOGGER = get_logger(name='standaone_solver', file_prefix='core')
+LOGGER = get_logger(name='standalone_solver', file_prefix='core')
 
 GET_RANDOM_RETRY_MAX = 10
 JOIN_TIMEOUT_SEC = 30


### PR DESCRIPTION
`standaone` を `standalone` に修正