### PR TITLE
Improve efficiency of misp_event

### DIFF
--- a/src/metemcyber/cli/cli.py
+++ b/src/metemcyber/cli/cli.py
@@ -2194,8 +2194,8 @@ def misp_event(ctx: typer.Context):
             event = _load_misp_event(file)
             metadata_cache[misp_hash] = (event.date, event.uuid, event.info)
     # delete metadata of not-found misp hash
-    for not_found in set(metadata_cache.keys()) - found:
-        metadata_cache.pop(not_found)
+    for deleted in set(metadata_cache.keys()) - found:
+        metadata_cache.pop(deleted)
     with open(metadata_cache_path, 'wb') as fp:
         pickle.dump(metadata_cache, fp)
 

--- a/src/metemcyber/cli/cli.py
+++ b/src/metemcyber/cli/cli.py
@@ -2171,8 +2171,9 @@ def _load_misp_event(filepath):
 def misp_event(ctx: typer.Context):
     json_dumpdir = Path(_load_config(ctx)['misp']['download'])
     # load metadata pickle for efficiency
-    if os.path.isdir(json_dumpdir):
-        metadata_cache_path = Path(json_dumpdir, 'downloaded_metadata_cache.pkl')
+    if not os.path.isdir(json_dumpdir):
+        raise FileNotFoundError(f'The directory of MISP download does not exist. ({json_dumpdir})')
+    metadata_cache_path = Path(json_dumpdir, '_download_metadata_cache.pkl')
     if os.path.isfile(metadata_cache_path):
         with open(metadata_cache_path, 'rb') as fp:
             try:

--- a/src/metemcyber/cli/cli.py
+++ b/src/metemcyber/cli/cli.py
@@ -2172,7 +2172,7 @@ def misp_event(ctx: typer.Context):
     json_dumpdir = Path(_load_config(ctx)['misp']['download'])
     # load metadata pickle for efficiency
     metadata_cache_path = Path(_load_config(ctx)['misp']['download'], '../metadata_cache.pkl')
-    if os.path.exists(metadata_cache_path):
+    if os.path.isfile(metadata_cache_path):
         with open(metadata_cache_path, 'rb') as fp:
             metadata_cache = pickle.load(fp)
     else:

--- a/src/metemcyber/cli/cli.py
+++ b/src/metemcyber/cli/cli.py
@@ -2174,7 +2174,11 @@ def misp_event(ctx: typer.Context):
     metadata_cache_path = Path(_load_config(ctx)['misp']['download'], '../metadata_cache.pkl')
     if os.path.isfile(metadata_cache_path):
         with open(metadata_cache_path, 'rb') as fp:
-            metadata_cache = pickle.load(fp)
+            try:
+                metadata_cache = pickle.load(fp)
+            except pickle.UnpicklingError as err:
+                typer.echo(err)
+                os.remove(metadata_cache_path)
     else:
         metadata_cache = {}
 

--- a/src/metemcyber/cli/cli.py
+++ b/src/metemcyber/cli/cli.py
@@ -2171,7 +2171,8 @@ def _load_misp_event(filepath):
 def misp_event(ctx: typer.Context):
     json_dumpdir = Path(_load_config(ctx)['misp']['download'])
     # load metadata pickle for efficiency
-    metadata_cache_path = Path(_load_config(ctx)['misp']['download'], '../metadata_cache.pkl')
+    if os.path.isdir(json_dumpdir):
+        metadata_cache_path = Path(json_dumpdir, 'metadata_cache.pkl')
     if os.path.isfile(metadata_cache_path):
         with open(metadata_cache_path, 'rb') as fp:
             try:

--- a/src/metemcyber/cli/cli.py
+++ b/src/metemcyber/cli/cli.py
@@ -2172,7 +2172,7 @@ def misp_event(ctx: typer.Context):
     json_dumpdir = Path(_load_config(ctx)['misp']['download'])
     # load metadata pickle for efficiency
     if os.path.isdir(json_dumpdir):
-        metadata_cache_path = Path(json_dumpdir, 'metadata_cache.pkl')
+        metadata_cache_path = Path(json_dumpdir, 'downloaded_metadata_cache.pkl')
     if os.path.isfile(metadata_cache_path):
         with open(metadata_cache_path, 'rb') as fp:
             try:


### PR DESCRIPTION
`misp_event`の動作速度改善を行いました。

- 各MISPオブジェクトJSONファイルに対してメタデータ取得と表示の2回解析を行っていた部分を統一
- JSONファイルのハッシュ値を用いて変更の有無を確認
  - 変更があればメタデータ再取得
    - 実データに紐づかなくなった変更前のキャッシュは削除
  - 変更がなければ`pickle`でキャッシュした辞書を使用

```sh
❯ ls -1 ~/Library/Application\ Support/metemcyber/misp/download/ | wc -l
73
❯ time metemctl misp event > /dev/null  # current
metemctl misp event > /dev/null  10.72s user 0.58s system 98% cpu 11.456 total
❯ git stash pop
(omission)
❯ time metemctl misp event > /dev/null  # improved-uncached
metemctl misp event > /dev/null  6.34s user 0.43s system 99% cpu 6.832 total
❯ time metemctl misp event > /dev/null  # improved-cached
metemctl misp event > /dev/null  1.47s user 0.22s system 97% cpu 1.738 total
```