### PR TITLE
make tx_decoder ignore keys increased after updating BESU

### DIFF
--- a/src/metemcyber/core/bc/monitor/tx_decoder.py
+++ b/src/metemcyber/core/bc/monitor/tx_decoder.py
@@ -138,7 +138,8 @@ class TransactionDecoder:
         return tmp if tmp > 0 else 1
 
     def simplify_tx(self, tx0: dict) -> dict:
-        skip_keys = {'blockHash', 'hash', 'nonce', 'r', 's', 'v', 'x_tx_receipt', 'x_block'}
+        skip_keys = {'blockHash', 'hash', 'nonce', 'r', 's', 'v', 'x_tx_receipt', 'x_block',
+                     'chainId', 'publicKey', 'raw'}
         skip_keys_on_zero = {'to', 'input', 'value'}
         tx0['x_receipt_status'] = tx0['x_tx_receipt'].status
         if tx0.get('input'):


### PR DESCRIPTION
先日のBESUバージョンアップで、トランザクション構造体にchainId, publicKey, rawの要素が追加されたようです。これらは参照していませんので、tx_decoder で無視するように調整しました。
直接的な影響として、tx_decoderでモニタした際、これらの要素が表示されなくなります（rawの表示が邪魔でした）。