### PR TITLE
Fix/enable local cors

### DIFF
--- a/src/metemcyber/core/asset_manager.py
+++ b/src/metemcyber/core/asset_manager.py
@@ -46,10 +46,11 @@ VALID_TIMESTAMP_RANGE = 12 * 3600  # 12 hours in sec
 SERVERLOG = get_logger(name='asset_mgr', file_prefix='core')
 CLIENTLOG = get_logger(name='asset_client', file_prefix='core')
 
-URLPATH_INFO = 'solver/api/info'
-URLPATH_MISP = 'solver/api/misp_object'
-URLPATH_LIST = 'solver/api/list_tokens'
-URLPATH_ACCEPT = 'solver/api/accept_tokens'
+URLPATH_PREFIX = 'solver/api'
+URLPATH_INFO = f'{URLPATH_PREFIX}/info'
+URLPATH_MISP = f'{URLPATH_PREFIX}/misp_object'
+URLPATH_LIST = f'{URLPATH_PREFIX}/list_tokens'
+URLPATH_ACCEPT = f'{URLPATH_PREFIX}/accept_tokens'
 
 CONFIG_SECTION = 'asset_manager'
 DEFAULT_CONFIGS = {

--- a/src/metemcyber/core/asset_manager.py
+++ b/src/metemcyber/core/asset_manager.py
@@ -144,7 +144,7 @@ class AssetManager:
         # Enable Cross-Origin Resource Sharing with localhost
         origins = [
             'http://localhost',
-            'http://localhost:3000'
+            'http://localhost:3000'  # webpotal-api
         ]
         self.app.add_middleware(
             CORSMiddleware,

--- a/src/metemcyber/core/asset_manager.py
+++ b/src/metemcyber/core/asset_manager.py
@@ -147,7 +147,7 @@ class AssetManager:
         ]
         self.app.add_middleware(
             CORSMiddleware,
-            allow_origin=origins,
+            allow_origins=origins,
             allow_credentials=True,
             allow_headers=['*'],
             allow_methods=['DELETE', 'GET', 'OPTION', 'POST']

--- a/src/metemcyber/core/asset_manager.py
+++ b/src/metemcyber/core/asset_manager.py
@@ -26,6 +26,7 @@ from urllib.request import Request, urlopen
 import uvicorn
 from eth_typing import ChecksumAddress
 from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
 from psutil import Process
 # pylint: disable=no-name-in-module
 from pydantic import BaseModel
@@ -138,6 +139,19 @@ class AssetManager:
         self.app.post(f'/{URLPATH_LIST}')(self._list_accepting)
         self.app.post(f'/{URLPATH_ACCEPT}')(self._post_accepting)
         self.app.delete(f'/{URLPATH_ACCEPT}')(self._delete_accepting)
+
+        # Enable Cross-Origin Resource Sharing with localhost
+        origins = [
+            'http://localhost',
+            'http://localhost:3000'
+        ]
+        self.app.add_middleware(
+            CORSMiddleware,
+            allow_origin=origins,
+            allow_credentials=True,
+            allow_headers=['*'],
+            allow_methods=['DELETE', 'GET', 'OPTION', 'POST']
+        )
 
     def _get_solver(self) -> MCSClient:  # CAUTION: do not cache client.
         solver = MCSClient(self.solver_account, APP_DIR)

--- a/src/metemcyber/core/asset_manager.py
+++ b/src/metemcyber/core/asset_manager.py
@@ -143,7 +143,6 @@ class AssetManager:
 
         # Enable Cross-Origin Resource Sharing with localhost
         origins = [
-            'http://localhost',
             'http://localhost:3000'  # webpotal-api
         ]
         self.app.add_middleware(

--- a/src/metemcyber/core/asset_manager.py
+++ b/src/metemcyber/core/asset_manager.py
@@ -46,10 +46,10 @@ VALID_TIMESTAMP_RANGE = 12 * 3600  # 12 hours in sec
 SERVERLOG = get_logger(name='asset_mgr', file_prefix='core')
 CLIENTLOG = get_logger(name='asset_client', file_prefix='core')
 
-URLPATH_INFO = 'info'
-URLPATH_MISP = 'misp_object'
-URLPATH_LIST = 'list_tokens'
-URLPATH_ACCEPT = 'accept_tokens'
+URLPATH_INFO = 'solver/api/info'
+URLPATH_MISP = 'solver/api/misp_object'
+URLPATH_LIST = 'solver/api/list_tokens'
+URLPATH_ACCEPT = 'solver/api/accept_tokens'
 
 CONFIG_SECTION = 'asset_manager'
 DEFAULT_CONFIGS = {


### PR DESCRIPTION
localhostで動作しているWebPortalからのAPI要求を受け入れるために `CORSMiddleware` を追加しました。

- `CORSMiddleware` のimport
- 動作に必要なパラメータの指定

付随して、WebPortal APIとの名前空間の衝突を避けるためにAPIエンドポイントの名前を変更しました。