### PR TITLE
Fix the problem of overwriting timestamp in the SignedRequest __init__

### DIFF
--- a/src/metemcyber/core/asset_manager.py
+++ b/src/metemcyber/core/asset_manager.py
@@ -70,7 +70,8 @@ class SignedRequest(BaseModel):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.timestamp = int(datetime.now().timestamp())
+        if self.timestamp == 0:
+            self.timestamp = int(datetime.now().timestamp())
 
     @property
     def string_to_sign(self) -> str:


### PR DESCRIPTION
`timestamp` を含むWebPortal上のAssetManager Clientからのリクエストを正しく処理できるように問題を修正しました。
- `SignedRequest` のスーパークラスコンストラクタで `timestamp` がパースされている（i.e. 初期値の `0` でない）場合、タイムスタンプを代入しないよう変更