### PR TITLE
make ix-use watch the event: challenge token returned

### DIFF
--- a/src/metemcyber/core/bc/token.py
+++ b/src/metemcyber/core/bc/token.py
@@ -101,6 +101,9 @@ class Token():
     def revoke_operator(self, *args, **kwargs):
         self._passthrough(*args, **kwargs)
 
+    def event_filter(self, *args, **kwargs):
+        return self._passthrough(*args, **kwargs)
+
     @property
     def editable(self) -> bool:
         return self._passthrough()


### PR DESCRIPTION
ix use でチャレンジ実行した後、当該トークンの返却イベントをモニタして表示するように改修しました。
本命は、solver 側で検知したエラー内容を表示する部分です。（このエラーメッセージは CTIToken.send の data 引数で渡される）
必ずしも分かりやすい内容とは限りませんが、webhook URL に接続できないとか、Solver side error だとかの区別ができるだけでも（特に開発時は）役立つかと思います。