### PR TITLE
Topic/command workspace

### DIFF
--- a/src/metemcyber/core/solver.py
+++ b/src/metemcyber/core/solver.py
@@ -122,7 +122,7 @@ class BaseSolver:
         self.account: Account = account
         self.operator_address: ChecksumAddress = operator_address
         self.listener: Optional[ChallengeListener] = None
-        self.config: ConfigParser = merge_config(config_path, {})
+        self.config: ConfigParser = merge_config(config_path, {})  # default is empty
 
     def destroy(self):
         LOGGER.info('destructing solver %s for %s', self, self.operator_address)


### PR DESCRIPTION
workspace 操作コマンドを実装しました。関連して、APP_DIR の初期化処理を微調整してあります。

注意点
- seeker が未だ追従できていません。設定の seeker.download_cti_path を WORKSPACE_PATH/download に設定してください。
- プロバイダの違い（pricom とか ganache とか）はサポートできていません。airdrop すると（ganache 設定でも）pricom で okawari されることになります。
- metemctl config edit で workspace の変更をできなくしました。エラー終了します。metemctl workspace switch を使用してください。
- workspace とみなされる条件は「APP_DIR 配下の workspace.NAME ディレクトリで、中に config.ini が存在する」です。config.ini は empty でも構いません。例外として、metemctl.ini に設定されている workspace（つまり現在の workspace）に限り、この条件を満たしていなくても workspace とみなしています（将来的には撤廃したい）。現行設定の内容によっては不整合が起きてしまうかもしれませんが、その場合は metemctl.ini あるいは config.ini を手作業で編集してください。orz

metemctl workspace のサブコマンドは、list, switch, create, copy, destroy です。でも create は使わなさそう。copy で複製して config edit で必要な分だけ調整するのが楽です。
workspace の使い分けとしては、プロバイダの切り替えの他に、CLI を実行するアカウントの切り替えなどを想定しています。workspace name として、それらの区別が付きやすい名称を推奨します。pricom.alice とか。
という訳で、アカウント切り替えが想定されるため、seeker, solver, asset manager の動作中は切り替えできません。