### PR TITLE
fix solver not to rely on general.workspace

### DIFF
--- a/src/metemcyber/cli/cli.py
+++ b/src/metemcyber/cli/cli.py
@@ -1263,11 +1263,15 @@ def _solver_start(ctx, enable):
         pass
     config = _load_config(ctx)
     endpoint_url = config['general']['endpoint_url']
+    workspace = config['general']['workspace']
     solv_cli_py = os.path.dirname(__file__) + '/../core/multi_solver_cli.py'
     # pylint: disable=consider-using-with
-    subprocess.Popen(
-        ['python3', solv_cli_py, '-e', endpoint_url, '-m', 'server', '-w', APP_DIR],
-        shell=False)
+    subprocess.Popen(['python3', solv_cli_py,
+                      '-e', endpoint_url,
+                      '-m', 'server',
+                      '-a', APP_DIR,
+                      '-w', workspace,
+                      ], shell=False)
     typer.echo('Solver started as a subprocess.')
     if enable:
         typer.echo('Enabling your operator.')

--- a/src/metemcyber/core/multi_solver_cli.py
+++ b/src/metemcyber/core/multi_solver_cli.py
@@ -28,7 +28,7 @@ LOGGER = get_logger(name='solver_client', file_prefix='core')
 
 def main(args):
     if args.mode == 'server':
-        server = MCSServer(args.work_dir, args.endpoint_url)
+        server = MCSServer(args.app_dir, args.endpoint_url, args.workspace)
         server.run()
     else:
         if args.keyfile:
@@ -54,9 +54,12 @@ OPTIONS: List[Tuple[str, str, dict]] = [
     ('-e', '--endpoint', dict(
         action='store', dest='endpoint_url', required=False,
         help='Ethereum Provider Endpoint URL')),
-    ('-w', '--workdir', dict(
-        action='store', dest='work_dir', required=True,
-        help='working dir where socket file is placed')),
+    ('-a', '--app_dir', dict(
+        action='store', dest='app_dir', required=True,
+        help='application dir where socket file is placed')),
+    ('-w', '--workspace', dict(
+        action='store', dest='workspace', required=False,
+        help='workspace dir (server mode only)')),
 ]
 
 if __name__ == '__main__':

--- a/src/metemcyber/core/solver.py
+++ b/src/metemcyber/core/solver.py
@@ -116,13 +116,20 @@ class ChallengeListener(BasicEventListener):
 
 
 class BaseSolver:
+    account: Account
+    operator_address: ChecksumAddress
+    listener: Optional[ChallengeListener]
+    config: ConfigParser
+    workspace: str
+
     def __init__(self, account: Account, operator_address: ChecksumAddress,
-                 config_path: Optional[str] = None) -> None:
+                 workspace: str, config_path: Optional[str] = None) -> None:
         LOGGER.info('initializing solver %s for %s', self, operator_address)
-        self.account: Account = account
-        self.operator_address: ChecksumAddress = operator_address
-        self.listener: Optional[ChallengeListener] = None
-        self.config: ConfigParser = merge_config(config_path, {})  # default is empty
+        self.account = account
+        self.operator_address = operator_address
+        self.listener = None
+        self.config = merge_config(config_path, {})  # default is empty
+        self.workspace = workspace
 
     def destroy(self):
         LOGGER.info('destructing solver %s for %s', self, self.operator_address)

--- a/src/metemcyber/plugins/gcs_solver.py
+++ b/src/metemcyber/plugins/gcs_solver.py
@@ -41,8 +41,8 @@ DEFAULT_CONFIGS = {
 
 class Solver(BaseSolver):
     def __init__(self, account: Account, operator_address: ChecksumAddress,
-                 config_file: Optional[str]) -> None:
-        super().__init__(account, operator_address)
+                 workspace: str, config_file: Optional[str]) -> None:
+        super().__init__(account, operator_address, workspace, config_file)
         self.config = merge_config(config_file, DEFAULT_CONFIGS, self.config)
         try:
             url = self.config[CONFIG_SECTION]['functions_url']
@@ -92,8 +92,7 @@ class Solver(BaseSolver):
             LOGGER.info('finished task %s', task_id)
 
     def upload_to_storage(self, cti_address):
-        file_path = os.path.abspath(
-            f"{self.config['general']['workspace']}/upload/{cti_address}")
+        file_path = os.path.abspath(f"{self.workspace}/upload/{cti_address}")
         url = self.uploader.upload_file(file_path)
         return url
 
@@ -114,7 +113,7 @@ class Uploader:
             with open(upload_path, 'r') as fin:
                 jdata = json.load(fin)
         except Exception as err:
-            raise Exception(f'Not a expected data format: {upload_path}') from err
+            raise Exception(f'Cannot open asset: {upload_path}: {err}') from err
         response = requests.post(
             self.url,
             json=jdata,

--- a/src/metemcyber/plugins/standalone_solver.py
+++ b/src/metemcyber/plugins/standalone_solver.py
@@ -107,13 +107,13 @@ class LocalHttpServer():
 
 class Solver(BaseSolver):
     def __init__(self, account: Account, operator_address: ChecksumAddress,
-                 config_path: Optional[str]) -> None:
-        super().__init__(account, operator_address)
+                 workspace: str, config_path: Optional[str]) -> None:
+        super().__init__(account, operator_address, workspace, config_path)
         self.config = merge_config(config_path, DEFAULT_CONFIGS, self.config)
         self.fileserver = LocalHttpServer(
             self.account.eoa,
             self.config[CONFIG_SECTION]['listen_address'],
-            f"{self.config['general']['workspace']}/upload")
+            f'{workspace}/upload')
         self.fileserver.start()
 
     def destroy(self):


### PR DESCRIPTION
workspace 機能により solver が動作しなくなった不具合を修正しました。
- solver が general.workspace を参照するのは正しくないため、config でなく独立パラメータとして指定するように改修しました。
- multi solver の work_dir が workspace と紛らわしいため、app_dir に変更しました。（値は cli から APP_DIR を設定しています）