### PR TITLE
Topic/add gui auto build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,59 @@
+name: "Build and release electron installer"
+on:
+  push:
+    tags:
+      - "gui-v*"
+
+jobs:
+  release:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [macos-latest]
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v1
+
+      - name: Install Node.js, NPM and Yarn
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14.15.5
+
+      - name: Build Electron app
+        uses: samuelmeuli/action-electron-builder@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          package_root: gui/
+          release: false
+
+      - name: Set App path
+        id: set_app_path
+        run: |
+          ARTIFACT_PATHNAME=$(ls gui/dist/*.dmg | head -n 1)
+          ARTIFACT_NAME=$(basename $ARTIFACT_PATHNAME)
+          echo "::set-output name=ARTIFACT_PATHNAME::$ARTIFACT_PATHNAME"
+          echo "::set-output name=ARTIFACT_NAME::$ARTIFACT_NAME"
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.github_token }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: "Release ${{ github.ref }}"
+          draft: false
+          prerelease: false
+
+      - name: Upload Release Asset
+        id: upload-release-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ steps.set_app_path.outputs.ARTIFACT_PATHNAME }}
+          asset_name: ${{ steps.set_app_path.outputs.ARTIFACT_NAME }}
+          asset_content_type: application/x-apple-diskimage

--- a/gui/package.json
+++ b/gui/package.json
@@ -51,8 +51,7 @@
     ],
     "development": [
       "last 1 chrome version",
-      "last 1 firefox version",
-      "last 1 safari version"
+      "last 1 firefox version"
     ]
   },
   "devDependencies": {
@@ -71,6 +70,7 @@
     "mac": {
       "target": "dmg",
       "icon": "public/logo512.png"
-    }
+    },
+    "publish": null
   }
 }

--- a/gui/package.json
+++ b/gui/package.json
@@ -51,7 +51,8 @@
     ],
     "development": [
       "last 1 chrome version",
-      "last 1 firefox version"
+      "last 1 firefox version",
+      "last 1 safari version"
     ]
   },
   "devDependencies": {


### PR DESCRIPTION
Electronアプリの自動ビルド用Github actionsワークフローを追加しました。

- "gui-v"で始まるタグをpushした場合にワークフローが開始されます。
  - 例：gui-v0.2.0
- ワークフロー実行後、ビルドされたdmgファイルがReleaseにて公開されます。
- ワークフロー内のbuild時に、package.json内にbuild/publishの項目を用意する必要がある為追加しました。