### PR TITLE
make solver support all registered tokens on enable

### DIFF
--- a/src/metemcyber/cli/cli.py
+++ b/src/metemcyber/cli/cli.py
@@ -1313,16 +1313,8 @@ def solver_enable(
 
 def _solver_enable(ctx, plugin):
     solver = _solver_enable_internal(ctx, plugin)
-
-    # start accept tokens already registered if exists.
-    population = _get_tokens_population(
-        ctx, mine=True, mine_only=True, soldout=True, own=True, own_only=False)
-    token_addresses = [t.address for lst in population.values() for t in lst]
-    if len(token_addresses) == 0:
-        return
-
     try:
-        msg = solver.solver('accept_registered', token_addresses)
+        msg = solver.solver('accept_registered', None)
         acceptings = solver.solver('accepting_tokens')
     except Exception as err:
         raise Exception(f'accepting registered tokens failed: {err}') from err

--- a/src/metemcyber/core/solver.py
+++ b/src/metemcyber/core/solver.py
@@ -149,7 +149,7 @@ class BaseSolver:
         accepting = self.accepting_tokens()
         cti_operator = CTIOperator(self.account).get(self.operator_address)
         if tokens is None:  # auto detect mode
-            targets = cti_operator.list_registered(self.operator_address)
+            targets = cti_operator.list_registered(self.account.eoa)
         else:
             registered = cti_operator.check_registered(tokens)
             targets = [


### PR DESCRIPTION
solver enable 時に、CTIOperator に register されている全てのトークンを support するように改修しました。
- 改修前は、solver EOA が発行したトークンのみでした。shared solver にマッチしないための改修です。
- CLI で solver enable 時に表示される有効化したトークン数も変化しますのでご留意ください。