### PR TITLE
Add error handling for login and data receipt

### DIFF
--- a/gui/package.json
+++ b/gui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Metemcyber-gui",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "main": "public/electron.js",
   "homepage": "./",

--- a/gui/src/containers/login.js
+++ b/gui/src/containers/login.js
@@ -32,6 +32,7 @@ function Login(props) {
     const [selectedKey, setSelectedKey] = useState({});
     const [keyModalToggle, setKeyModalToggle] = useState(false);
     const [errorModalToggle, setErrorModalToggle] = useState(false);
+    const [errorMessage, setErrorMessage] = useState('');
     const [settingModalToggle, setSettingModalToggle] = useState(false);
     const [urlValue, setUrlValue] = useState('');
     const [setup, setSetup] = useState(true);
@@ -47,10 +48,10 @@ function Login(props) {
     const handleSubmit = () => {
         setLoading(true);
         ipcRenderer.once('login', (event, arg) => {
-            console.log(arg)
-            if (arg) {
+            if (arg.commandStatus) {
                 props.history.push('/contents');
             }
+            setErrorMessage(arg.message);
             setErrorModalToggle(true);
             setLoading(false);
         });
@@ -170,7 +171,8 @@ function Login(props) {
             <Modal isOpen={errorModalToggle} toggle={toggleErrorModal} >
                 <ModalHeader >Error</ModalHeader>
                 <ModalBody>
-                    Password is incorrect.
+                    <p>An error has occurred.</p>
+                    <ErrorParagraph>{errorMessage}</ErrorParagraph>
                 </ModalBody>
                 <ModalFooter>
                     <Button color="primary" onClick={toggleErrorModal}>OK</Button>{' '}
@@ -243,4 +245,8 @@ const UrlInput = styled(Input)`
 
 const HeaderButton = styled(Button)`
     margin: 0 5px;
+`;
+
+const ErrorParagraph = styled.p`
+    color: red;
 `;


### PR DESCRIPTION
GUIのエラーハンドリングの追加および修正を行いました。

追加および修正箇所
- ログイン処理時のエラーハンドリングを修正しました。
- 各データ取得時のエラーハンドリングを追加しました。

修正内容
- metemctl実行時に'failed operation:'を含む実行結果が返された場合、エラーモーダルを表示します。
- エラーモーダルにエラーメッセージを表示するように修正しました。
- ログイン後の初回データ取得時にエラーが発生した場合、モーダル終了時にログイン画面へ遷移します。