### PR TITLE
make tx-monitor support websocket

### DIFF
--- a/src/metemcyber/core/bc/monitor/tx_dumper.py
+++ b/src/metemcyber/core/bc/monitor/tx_dumper.py
@@ -40,7 +40,13 @@ class TransactionDumper:
         endpoint = self.conf['endpoint']
         db_filepath = self.conf['db_filepath_raw']
 
-        self.web3 = Web3(HTTPProvider(endpoint))
+        scheme = endpoint.split(':', 1)[0]
+        if scheme in {'http', 'https'}:
+            self.web3 = Web3(HTTPProvider(endpoint))
+        elif scheme in {'ws', 'wss'}:
+            self.web3 = Web3(Web3.WebsocketProvider(endpoint))
+        else:
+            raise Exception(f'Not supported scheme: {endpoint}')
         try:
             self.web3.eth.get_block('latest')
         except ExtraDataLengthError:


### PR DESCRIPTION
トランザクションモニタでも websocket を使えるようにしました。
ただし、誤操作防止のため DB に endpoint を格納してあるため、途中でスキーム（endpoint url）を切り替えるとエラーになります。回避するには、３つの DB それぞれの、endpoint を新しい endpoint url に書き換える必要があります。（レアケースですし、手動実行も容易なのでマイグレーションツールの類は用意しません）