### PR TITLE
Topic/fix for mp safe

### DIFF
--- a/src/metemcyber/cli/cli.py
+++ b/src/metemcyber/cli/cli.py
@@ -1146,7 +1146,7 @@ def _local_solver_obsolete(ctx, token):
                       help='Start Asset Manager service.')
 @common_logging
 def assetmgr_start(ctx: typer.Context):
-    ctrl = AssetManagerController(_load_solver_account(ctx), load_config(ctx))
+    ctrl = AssetManagerController(load_config(ctx))
     if ctrl.pid > 0:
         raise Exception('Asset Manager already running.')
     ctrl.start()
@@ -1162,7 +1162,7 @@ def assetmgr_stop(ctx: typer.Context):
 
 
 def _assetmgr_stop(ctx):
-    ctrl = AssetManagerController(_load_solver_account(ctx), load_config(ctx))
+    ctrl = AssetManagerController(load_config(ctx))
     if ctrl.pid == 0:
         raise Exception('Asset Manager not running')
     ctrl.stop()
@@ -1181,7 +1181,7 @@ def _assetmgr_status(ctx) -> Tuple[bool, str]:
     for key in ['endpoint_url', 'keyfile', 'operator.address']:
         if not OmegaConf.select(config.workspace, key):
             return False, 'not configured'
-    ctrl = AssetManagerController(_load_solver_account(ctx), config)
+    ctrl = AssetManagerController(config)
     if ctrl.pid == 0:
         return False, 'not running.'
     return True, f'running on pid {ctrl.pid}, listening {ctrl.listen_address}:{ctrl.listen_port}.'

--- a/src/metemcyber/cli/cli.py
+++ b/src/metemcyber/cli/cli.py
@@ -157,7 +157,7 @@ def _load_account(ctx: typer.Context) -> Account:
     for key in required:
         if OmegaConf.is_missing(config, key) or not OmegaConf.select(config, key):
             raise Exception(f'Missing configuration: {key}')
-    eoaa, pkey = decode_keyfile(config.workspace.keyfile, config.workspace.keyfile_password)
+    eoaa, pkey, _ = decode_keyfile(config.workspace.keyfile, config.workspace.keyfile_password)
     account = Account(Ether(config.workspace.endpoint_url), eoaa, pkey)
     ctx.meta['account'] = account
     return account
@@ -171,8 +171,8 @@ def _load_solver_account(ctx: typer.Context) -> Account:
     for key in required:
         if not OmegaConf.select(config, key):
             raise Exception(f'Missing configuration: {key}')
-    eoaa, pkey = decode_keyfile(config.workspace.solver.keyfile,
-                                config.workspace.solver.keyfile_password)
+    eoaa, pkey, _ = decode_keyfile(config.workspace.solver.keyfile,
+                                   config.workspace.solver.keyfile_password)
     solver_account = Account(Ether(config.workspace.endpoint_url), eoaa, pkey)
     ctx.meta['solver_account'] = solver_account
     return solver_account
@@ -1011,14 +1011,14 @@ def _local_solver_status(ctx: typer.Context) -> Tuple[bool, str]:
     for key in ['endpoint_url', 'keyfile', 'operator.address']:
         if not OmegaConf.select(config.workspace, key):
             return False, 'not configured'
-    ctrl = SolverController(_load_solver_account(ctx), config)
+    ctrl = SolverController(config)
     if ctrl.pid <= 0:
         return False, 'not running'
     if ctrl.operator_address == _load_operator(ctx).address:
-        msg = (f'Solver running on pid {ctrl.pid} with EOA({ctrl.account.eoa}) '
+        msg = (f'Solver running on pid {ctrl.pid} with EOA({ctrl.solver_eoaa}) '
                f'with operator({ctrl.operator_address}).')
     else:
-        msg = (f'[WARNING] Solver running with EOA({ctrl.account.eoa}) '
+        msg = (f'[WARNING] Solver running with EOA({ctrl.solver_eoaa}) '
                f'with ANOTHER operator({ctrl.operator_address}).')
     return True, msg
 
@@ -1027,12 +1027,7 @@ def _local_solver_status(ctx: typer.Context) -> Tuple[bool, str]:
                     help='Start Solver process.')
 @common_logging
 def solver_start(ctx: typer.Context):
-    try:
-        _solver_client(ctx)
-        raise Exception('Solver already running.')
-    except Exception:
-        pass
-    ctrl = SolverController(_load_solver_account(ctx), load_config(ctx))
+    ctrl = SolverController(load_config(ctx))
     ctrl.start()
     typer.echo(f'Solver started as a subprocess(pid={ctrl.pid}).')
 
@@ -1041,7 +1036,7 @@ def solver_start(ctx: typer.Context):
                     help='Kill Solver process, all solver (not only yours) are killed.')
 @common_logging
 def solver_stop(ctx: typer.Context):
-    ctrl = SolverController(_load_solver_account(ctx), load_config(ctx))
+    ctrl = SolverController(load_config(ctx))
     ctrl.stop()
     typer.echo('Solver shutted down.')
 

--- a/src/metemcyber/cli/config.py
+++ b/src/metemcyber/cli/config.py
@@ -52,7 +52,7 @@ WORKSPACE_MINIMAL_DIRS = {
 }
 
 
-def decode_keyfile(keyfile: str, pw_candidate: Optional[str]) -> Tuple[ChecksumAddress, str]:
+def decode_keyfile(keyfile: str, pw_candidate: Optional[str]) -> Tuple[ChecksumAddress, str, str]:
     def pwf():
         return pw_candidate or typer.prompt('Enter password for keyfile', hide_input=True)
     return util_decode_keyfile(keyfile, password_func=pwf)
@@ -91,7 +91,7 @@ def _keyfile_validator(keyfile: str, keyfile_password: str,
                        echo: Callable[..., None] = _fake_echo, pref: str = ''):
     if keyfile and keyfile_password:
         try:
-            eoaa, _pkey = decode_keyfile(keyfile, keyfile_password)
+            eoaa, _pkey, _ = decode_keyfile(keyfile, keyfile_password)
             echo(f'ok: {pref}valid for EOA {eoaa}.')
         except Exception as err:
             raise Exception(f'{pref}{err}') from err
@@ -361,7 +361,7 @@ class WorkspaceConfig:
             if issubclass(kcls, BCValidator):
                 if not account:
                     echo('validating contracts with EOA.')
-                    eoaa, pkey = decode_keyfile(dconf.keyfile, dconf.keyfile_password)
+                    eoaa, pkey, _ = decode_keyfile(dconf.keyfile, dconf.keyfile_password)
                     account = Account(Ether(dconf.endpoint_url), eoaa, pkey)
                 kcls.bc_validator(dconf[key], account, echo=echo, pref=f'{pref}{key}.')
             if hasattr(kcls, 'validator'):

--- a/src/metemcyber/core/asset_manager.py
+++ b/src/metemcyber/core/asset_manager.py
@@ -150,7 +150,7 @@ class AssetManager:
         )
 
     def _solver_ctrl(self) -> SolverController:
-        return SolverController(self.solver_account, self.config)
+        return SolverController(self.config)
 
     def _get_solver(self) -> SolverClient:  # CAUTION: do not cache client.
         client = SolverClient(self.solver_account, self.config)

--- a/src/metemcyber/core/bc/util.py
+++ b/src/metemcyber/core/bc/util.py
@@ -43,14 +43,14 @@ def verify_message(message: str, signature: str) -> ChecksumAddress:
 
 def decode_keyfile(filename: str,
                    password_func: Callable[[], str] = lambda: getpass('Enter password for keyfile:')
-                   ) -> Tuple[ChecksumAddress, str]:
+                   ) -> Tuple[ChecksumAddress, str, str]:
     # https://web3py.readthedocs.io/en/stable/web3.eth.account.html#extract-private-key-from-geth-keyfile
     with open(filename, encoding='utf-8') as keyfile:
         enc_data = keyfile.read()
     address = Web3.toChecksumAddress(json.loads(enc_data)['address'])
     word = password_func()
     private_key = w3.eth.account.decrypt(enc_data, word).hex()
-    return Web3.toChecksumAddress(address), private_key
+    return Web3.toChecksumAddress(address), private_key, word
 
 
 def deploy_erc1820(eoa: ChecksumAddress, web3: Web3) -> None:


### PR DESCRIPTION
WebsocketProvider がマルチプロセスセーフでなかったため、solver, asset-manager, seeker の起動に fork を使わないように改修しました。
- MP-safe でないのは、WebsocketProvider が asynio 用のイベントループを別スレッドで駆動し、そのスレッドをクラス変数で保持していることが原因です。fork するとイベントループ用スレッドにアクセスできなくなるため、asyncio が全て動作しなくなります。
- metemctl 自体も eventlistener などスレッドを使用していますので、fork の使用は潜在的に危険な状態でした。
- solver, asset-manager は solver アカウント用の keyfile decode password が必要ですが、fork を廃止したことでサブプロセスへの継承が難しくなりました。対処のため decode_keyfile() が（プロンプトで入力した）パスワードも返すように変更しています。

なお、この改修で fork 後に WebsocketProvider が動作しない問題は解決していますが、別途、WebsocketProvider が（おそらく）マルチスレッドセーフでない問題が発覚しています。websocket を利用するには、そちらも解決する必要がありそうです。