### PR TITLE
Topic/fix design collapse

### DIFF
--- a/gui/public/electron.js
+++ b/gui/public/electron.js
@@ -79,13 +79,6 @@ app.whenReady().then(() => {
   })
 })
 
-// Quit when all windows are closed, except on macOS. There, it's common
-// for applications and their menu bar to stay active until the user quits
-// explicitly with Cmd + Q.
-app.on('window-all-closed', function () {
-  if (process.platform !== 'darwin') app.quit()
-})
-
 
 ipcMain.on('logout', async (event, arg) => {
   process.env.METEMCTL_KEYFILE_PASSWORD = '';

--- a/gui/public/electron.js
+++ b/gui/public/electron.js
@@ -35,6 +35,8 @@ async function createWindow() {
   const mainWindow = new BrowserWindow({
     width: 1600,
     height: 1200,
+    minHeight: 500,
+    minWidth: 865,
     webPreferences: {
       preload: path.join(__dirname, 'preload.js')
     }

--- a/gui/public/electron.js
+++ b/gui/public/electron.js
@@ -61,9 +61,6 @@ async function createWindow() {
   if (!store.get('TRANSACTION_API_URL', false)) {
     store.set('TRANSACTION_API_URL', '')
   }
-
-  // Open the DevTools.
-  mainWindow.webContents.openDevTools()
 }
 
 // This method will be called when Electron has finished

--- a/gui/src/containers/defaultLayout.js
+++ b/gui/src/containers/defaultLayout.js
@@ -200,7 +200,7 @@ function DefaultLayout(props) {
                                 </LogoutNav>
                             </SideNav>
                         </ColSideNav>
-                        <ColNoGutter xs="10" >
+                        <ColNoGutter>
                             <Row>
                                 <Col xs="12">
                                     <MainContent>
@@ -267,6 +267,7 @@ export const SideNav = styled(Nav)`
 
 export const ColSideNav = styled(Col)`
     padding-right: 0px;
+    min-width: 220px;
 `;
 
 export const ColNoGutter = styled(Col)`
@@ -281,7 +282,6 @@ export const SideNavTitle = styled(NavbarBrand)`
     text-align: center;
     padding: 15px;
     margin-right: 0px;
-    margin-bottom: 30px;
 `;
 export const SideNavSubTitle = styled(NavbarBrand)`
     font-size: 17px;


### PR DESCRIPTION
- ウィンドウの最低サイズ及びサイドバーの最低幅を追加し、サイドバーの表示崩れを修正しました。
- （リファクタリング）ウィンドウをクローズした際に、アプリケーションが起動状態を保持する設定になっていた為、アプリケーションが終了するように変更しました。
- （リファクタリング）アプリケーション起動時に開発者ツールがデフォルトで表示されていた為、非表示に変更しました。